### PR TITLE
feat: add edit form for memberships

### DIFF
--- a/locales/hive.yaml
+++ b/locales/hive.yaml
@@ -475,6 +475,9 @@ groups.members.list.action.delete.subgroup.confirm:
 groups.members.list.action.delete.tooltip:
   en: Revoke membership
   sv: Återkalla medlemskapet
+groups.members.list.action.edit.tooltip:
+  en: Edit membership
+  sv: Redigera medlemskap
 groups.members.list.col.details:
   en: Details
   sv: Detaljer
@@ -520,6 +523,9 @@ groups.members.list.icon.user:
 groups.members.list.tooltip.inclusive:
   en: (Inclusive)
   sv: (Inklusive)
+groups.members.edit.title:
+  en: Edit membership
+  sv: Redigera medlemskap
 groups.permissions.assign.field.perm.indicator.scoped:
   en: Scoped
   sv: Avgränsat

--- a/locales/hive.yaml
+++ b/locales/hive.yaml
@@ -458,6 +458,9 @@ groups.members.add.subgroup.field.manager.tip:
 groups.members.add.subgroup.success:
   en: Successfully added "%{x}" as a subgroup!
   sv: Lade till "%{x}" som en undergrupp!
+groups.members.edit.title:
+  en: Edit membership
+  sv: Redigera medlemskap
 groups.members.list.action.delete.direct-member.confirm:
   en: >
     Are you sure you want to revoke "%{x}"'s membership in this group?
@@ -523,9 +526,6 @@ groups.members.list.icon.user:
 groups.members.list.tooltip.inclusive:
   en: (Inclusive)
   sv: (Inklusive)
-groups.members.edit.title:
-  en: Edit membership
-  sv: Redigera medlemskap
 groups.permissions.assign.field.perm.indicator.scoped:
   en: Scoped
   sv: Avgränsat

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -67,6 +67,18 @@ impl form::validate::Len<usize> for TrimmedStr<'_> {
     }
 }
 
+impl PartialEq<String> for TrimmedStr<'_> {
+    fn eq(&self, other: &String) -> bool {
+         (self.0) == *other
+    }
+}
+
+impl PartialEq<TrimmedStr<'_>> for String {
+    fn eq(&self, other: &TrimmedStr) -> bool {
+        *other == *self
+    }
+}
+
 fn valid_slug<'v, T: Into<&'v str>>(s: T) -> form::Result<'v, ()> {
     let re = Regex::new("^[a-z0-9]+(-[a-z0-9]+)*$").unwrap();
 

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -69,7 +69,7 @@ impl form::validate::Len<usize> for TrimmedStr<'_> {
 
 impl PartialEq<String> for TrimmedStr<'_> {
     fn eq(&self, other: &String) -> bool {
-         (self.0) == *other
+        (self.0) == *other
     }
 }
 

--- a/src/dto/datetime.rs
+++ b/src/dto/datetime.rs
@@ -42,7 +42,7 @@ impl<'f> form::FromFormField<'f> for BrowserDateTimeDto {
     }
 }
 
-#[derive(sqlx::Type, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(sqlx::Type, Serialize, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 #[sqlx(transparent)]
 #[serde(transparent)]
 pub struct BrowserDateDto(pub NaiveDate);
@@ -61,5 +61,17 @@ impl<'f> form::FromFormField<'f> for BrowserDateDto {
         } else {
             Err(form::Error::validation("invalid date format").into())
         }
+    }
+}
+
+impl PartialEq<NaiveDate> for BrowserDateDto {
+    fn eq(&self, other: &NaiveDate) -> bool {
+        self.0 == *other
+    }
+}
+
+impl From<BrowserDateDto> for serde_json::Value {
+    fn from(value: BrowserDateDto) -> Self {
+        serde_json::Value::from(value.to_string())
     }
 }

--- a/src/dto/errors.rs
+++ b/src/dto/errors.rs
@@ -89,8 +89,8 @@ enum InnerAppErrorDto {
     #[serde(rename = "group.add.membership.redundant")]
     RedundantMembership { username: String },
 
-    #[serde(rename = "member.unknown")]
-    NoSuchMember { id: String },
+    #[serde(rename = "membership.unknown")]
+    NoSuchMembership { id: String },
 }
 
 impl From<AppError> for InnerAppErrorDto {
@@ -169,7 +169,7 @@ impl From<AppError> for InnerAppErrorDto {
             },
             AppError::RedundantMembership(username) => Self::RedundantMembership { username },
 
-            AppError::NoSuchMember(id) => Self::NoSuchMember { id }
+            AppError::NoSuchMembership(id) => Self::NoSuchMembership { id }
         }
     }
 }
@@ -260,8 +260,8 @@ impl InnerAppErrorDto {
             (Self::DuplicateSubgroup { .. }, Language::Swedish) => "Duplicerat undergrupp",
             (Self::RedundantMembership { .. }, Language::English) => "Redundant Membership",
             (Self::RedundantMembership { .. }, Language::Swedish) => "Överflödigt medlemskap",
-            (Self::NoSuchMember { .. }, Language::English) => "Unknown Member",
-            (Self::NoSuchMember { .. }, Language::Swedish) => "Okänd medlem",
+            (Self::NoSuchMembership { .. }, Language::English) => "Unknown Membership",
+            (Self::NoSuchMembership { .. }, Language::Swedish) => "Okänt medlemskap",
         }
     }
 
@@ -628,11 +628,11 @@ impl InnerAppErrorDto {
                      perioden med motsvarande åtkomsträttigheter."
                 )
             }
-            (Self::NoSuchMember { id }, Language::English) => {
-                format!("Could not find any member with key \"{id}\".")
+            (Self::NoSuchMembership { id }, Language::English) => {
+                format!("Could not find any group membership with key \"{id}\".")
             }
-            (Self::NoSuchMember { id }, Language::Swedish) => {
-                format!("Kunde inte hitta någon medlem med nyckel \"{id}\".")
+            (Self::NoSuchMembership { id }, Language::Swedish) => {
+                format!("Kunde inte hitta något gruppmedlemskap med nyckel \"{id}\".")
             }
         }
     }

--- a/src/dto/errors.rs
+++ b/src/dto/errors.rs
@@ -88,6 +88,9 @@ enum InnerAppErrorDto {
     },
     #[serde(rename = "group.add.membership.redundant")]
     RedundantMembership { username: String },
+
+    #[serde(rename = "member.unknown")]
+    NoSuchMember { id: String },
 }
 
 impl From<AppError> for InnerAppErrorDto {
@@ -165,6 +168,8 @@ impl From<AppError> for InnerAppErrorDto {
                 child_domain: domain,
             },
             AppError::RedundantMembership(username) => Self::RedundantMembership { username },
+
+            AppError::NoSuchMember(id) => Self::NoSuchMember { id }
         }
     }
 }
@@ -255,6 +260,8 @@ impl InnerAppErrorDto {
             (Self::DuplicateSubgroup { .. }, Language::Swedish) => "Duplicerat undergrupp",
             (Self::RedundantMembership { .. }, Language::English) => "Redundant Membership",
             (Self::RedundantMembership { .. }, Language::Swedish) => "Överflödigt medlemskap",
+            (Self::NoSuchMember { .. }, Language::English) => "Unknown Member",
+            (Self::NoSuchMember { .. }, Language::Swedish) => "Okänd medlem",
         }
     }
 
@@ -620,6 +627,12 @@ impl InnerAppErrorDto {
                     "Användaren \"{username}\" är redan medlem i denna grupp under den angivna \
                      perioden med motsvarande åtkomsträttigheter."
                 )
+            }
+            (Self::NoSuchMember { id }, Language::English) => {
+                format!("Could not find any member with key \"{id}\".")
+            }
+            (Self::NoSuchMember { id }, Language::Swedish) => {
+                format!("Kunde inte hitta någon medlem med nyckel \"{id}\".")
             }
         }
     }

--- a/src/dto/errors.rs
+++ b/src/dto/errors.rs
@@ -169,7 +169,7 @@ impl From<AppError> for InnerAppErrorDto {
             },
             AppError::RedundantMembership(username) => Self::RedundantMembership { username },
 
-            AppError::NoSuchMembership(id) => Self::NoSuchMembership { id }
+            AppError::NoSuchMembership(id) => Self::NoSuchMembership { id },
         }
     }
 }

--- a/src/dto/groups.rs
+++ b/src/dto/groups.rs
@@ -70,3 +70,10 @@ pub struct AddMemberDto<'v> {
     pub until: BrowserDateDto,
     pub manager: bool,
 }
+
+#[derive(FromForm)]
+pub struct EditMemberDto {
+    pub from: BrowserDateDto,
+    #[field(validate = with(|until| until >= &self.from, "invalid until before from"))]
+    pub until: BrowserDateDto,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -98,6 +98,9 @@ pub enum AppError {
     DuplicateSubgroup(String, String),
     #[error("user `{0}` is already a member of this group within the specified period")]
     RedundantMembership(String),
+
+    #[error("could not find member with id `{0}`")]
+    NoSuchMember(String),
 }
 
 impl AppError {
@@ -151,6 +154,7 @@ impl AppError {
             AppError::InvalidSubgroup(..) => Status::BadRequest,
             AppError::DuplicateSubgroup(..) => Status::Conflict,
             AppError::RedundantMembership(..) => Status::Conflict,
+            AppError::NoSuchMember(..) => Status::NotFound,
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -99,8 +99,8 @@ pub enum AppError {
     #[error("user `{0}` is already a member of this group within the specified period")]
     RedundantMembership(String),
 
-    #[error("could not find member with id `{0}`")]
-    NoSuchMember(String),
+    #[error("could not find any group membership with id `{0}`")]
+    NoSuchMembership(String),
 }
 
 impl AppError {
@@ -154,7 +154,7 @@ impl AppError {
             AppError::InvalidSubgroup(..) => Status::BadRequest,
             AppError::DuplicateSubgroup(..) => Status::Conflict,
             AppError::RedundantMembership(..) => Status::Conflict,
-            AppError::NoSuchMember(..) => Status::NotFound,
+            AppError::NoSuchMembership(..) => Status::NotFound,
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -111,7 +111,7 @@ pub trait GroupModel: for<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> + Send + 
 impl GroupModel for Group {}
 impl GroupModel for SimpleGroup {}
 
-#[derive(FromRow)]
+#[derive(FromRow, Debug)]
 pub struct GroupMember {
     #[sqlx(default)]
     pub id: Option<Uuid>, // only exists for direct memberships

--- a/src/services.rs
+++ b/src/services.rs
@@ -25,11 +25,11 @@ macro_rules! pg_args {
 
 macro_rules! update_if_changed {
     ($map:expr, $query:expr, $prop:ident, $old:expr, $new:expr) => {
-        if $old.$prop != *$new.$prop {
+        if $old.$prop != $new.$prop {
             if !$map.is_empty() {
                 $query.push(", ");
             }
-            $query.push(format!(" {} = ", stringify!($prop)));
+            $query.push(format!(" \"{}\" = ", stringify!($prop)));
             $query.push_bind($new.$prop);
 
             $map.insert(

--- a/src/services/groups/members.rs
+++ b/src/services/groups/members.rs
@@ -584,7 +584,7 @@ where
     Ok(())
 }
 
-// Returns true if is until time is allowed based on the appointment-bounds
+// Returns true if `until` time is allowed based on the appointment bounds
 // constraints
 pub async fn check_appointment_bounds<'x, X>(
     until: &NaiveDate,
@@ -638,6 +638,7 @@ where
     let total_months = total_months.clamp(0, u8::MAX as _) as u8;
 
     let min = HivePermission::LongTermAppointment(UpperBoundScope::UpTo(total_months));
+
     perms.satisfies(min).await
 }
 

--- a/src/services/groups/members.rs
+++ b/src/services/groups/members.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use chrono::{Local, NaiveDate};
+use chrono::{Date, Datelike, Local, NaiveDate};
 use log::*;
+use rocket::form::Contextual;
 use serde_json::json;
 use sqlx::Row;
 use uuid::Uuid;
@@ -12,10 +13,11 @@ use crate::{
         groups::{AddMemberDto, AddSubgroupDto, EditMemberDto},
     },
     errors::{AppError, AppResult},
-    guards::user::User,
+    guards::{perms::PermsEvaluator, user::User},
     models::{ActionKind, GroupMember, Subgroup, TargetKind},
+    perms::{HivePermission, UpperBoundScope},
     resolver::IdentityResolver,
-    services::{audit_log_details_for_update, audit_logs, update_if_changed},
+    services::{audit_log_details_for_update, audit_logs, groups, update_if_changed},
 };
 
 pub async fn get_one<'x, X>(membership_id: &Uuid, db: X) -> AppResult<Option<GroupMember>>
@@ -437,6 +439,32 @@ where
     let mut txn = db.begin().await?;
 
     let old = require_one(membership_id, &mut *txn).await?;
+
+    let redundant = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0
+        FROM direct_memberships
+        WHERE username = $1
+            AND group_id = $2
+            AND group_domain = $3
+            AND \"from\" <= $4
+            AND \"until\" >= $5
+            AND manager >= $6
+            AND id <> $7",
+    )
+    .bind(&old.username)
+    .bind(group_id)
+    .bind(group_domain)
+    .bind(&dto.from)
+    .bind(&dto.until)
+    .bind(old.manager)
+    .bind(membership_id)
+    .fetch_one(&mut *txn)
+    .await?;
+
+    if redundant {
+        return Err(AppError::RedundantMembership(old.username.to_string()));
+    }
+
     let old = EditMemberDto {
         from: BrowserDateDto(old.from),
         until: BrowserDateDto(old.until),
@@ -558,6 +586,62 @@ where
     txn.commit().await?;
 
     Ok(())
+}
+
+// Returns true if is until time is allowed based on the appointment-bounds constraints
+pub async fn check_appointment_bounds<'x, X>(
+    until: &NaiveDate,
+    id: &str,
+    domain: &str,
+    perms: &PermsEvaluator,
+    db: X,
+) -> AppResult<bool>
+where
+    X: sqlx::Acquire<'x, Database = sqlx::Postgres>,
+{
+    let mut txn = db.begin().await?;
+
+    let exempt = groups::tags::is_tagged_with(
+        id,
+        domain,
+        crate::HIVE_SYSTEM_ID,
+        "appointment-bounds-exemption",
+        &mut *txn,
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    if exempt {
+        return Ok(true);
+    }
+
+    // the default limit for membership upper bound is either 31/Dec of the current
+    // year or 30/Jun of the following year, whichever is closer but more
+    // than 6 months away
+    let today = Local::now().date_naive();
+    let limit = if today < NaiveDate::from_ymd_opt(today.year(), 6, 30).unwrap() {
+        NaiveDate::from_ymd_opt(today.year(), 12, 31).unwrap()
+    } else {
+        NaiveDate::from_ymd_opt(today.year() + 1, 6, 30).unwrap()
+    };
+
+    if *until <= limit {
+        return Ok(true);
+    }
+
+    // outside of base case, so need special permission
+
+    let years_diff = until.year() - today.year();
+    let months_diff = until.month() as i32 - today.month() as i32;
+    let mut total_months = years_diff * 12 + months_diff;
+    if until.day() > today.day() {
+        total_months += 1; // adjust rounding up
+    }
+    let total_months = total_months.clamp(0, u8::MAX as _) as u8;
+
+    let min = HivePermission::LongTermAppointment(UpperBoundScope::UpTo(total_months));
+    perms.satisfies(min).await
 }
 
 pub async fn conditional_bootstrap<'x, X>(username: &str, db: X) -> AppResult<bool>

--- a/src/services/groups/members.rs
+++ b/src/services/groups/members.rs
@@ -36,7 +36,7 @@ where
 {
     get_one(membership_id, db)
         .await?
-        .ok_or_else(|| AppError::NoSuchMember(membership_id.to_string()))
+        .ok_or_else(|| AppError::NoSuchMembership(membership_id.to_string()))
 }
 
 pub async fn is_direct_member<'x, X>(

--- a/src/services/groups/members.rs
+++ b/src/services/groups/members.rs
@@ -480,10 +480,6 @@ where
         query
             .push(" WHERE id = ")
             .push_bind(membership_id)
-            .push(" AND group_id  = ")
-            .push_bind(group_id)
-            .push(" AND group_domain = ")
-            .push_bind(group_domain)
             .build()
             .execute(&mut *txn)
             .await?;

--- a/src/services/groups/members.rs
+++ b/src/services/groups/members.rs
@@ -584,7 +584,8 @@ where
     Ok(())
 }
 
-// Returns true if is until time is allowed based on the appointment-bounds constraints
+// Returns true if is until time is allowed based on the appointment-bounds
+// constraints
 pub async fn check_appointment_bounds<'x, X>(
     until: &NaiveDate,
     id: &str,

--- a/src/services/groups/members.rs
+++ b/src/services/groups/members.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::{Local, NaiveDate};
 use log::*;
 use serde_json::json;
@@ -5,13 +7,37 @@ use sqlx::Row;
 use uuid::Uuid;
 
 use crate::{
-    dto::groups::{AddMemberDto, AddSubgroupDto},
+    dto::{
+        datetime::BrowserDateDto,
+        groups::{AddMemberDto, AddSubgroupDto, EditMemberDto},
+    },
     errors::{AppError, AppResult},
     guards::user::User,
     models::{ActionKind, GroupMember, Subgroup, TargetKind},
     resolver::IdentityResolver,
-    services::audit_logs,
+    services::{audit_log_details_for_update, audit_logs, update_if_changed},
 };
+
+pub async fn get_one<'x, X>(membership_id: &Uuid, db: X) -> AppResult<Option<GroupMember>>
+where
+    X: sqlx::Executor<'x, Database = sqlx::Postgres>,
+{
+    let group = sqlx::query_as("SELECT * FROM direct_memberships WHERE id = $1")
+        .bind(membership_id)
+        .fetch_optional(db)
+        .await?;
+
+    Ok(group)
+}
+
+pub async fn require_one<'x, X>(membership_id: &Uuid, db: X) -> AppResult<GroupMember>
+where
+    X: sqlx::Executor<'x, Database = sqlx::Postgres>,
+{
+    get_one(membership_id, db)
+        .await?
+        .ok_or_else(|| AppError::NoSuchMember(membership_id.to_string()))
+}
 
 pub async fn is_direct_member<'x, X>(
     username: &str,
@@ -395,6 +421,60 @@ where
     }
 
     Ok(added)
+}
+
+pub async fn update<'x, X>(
+    membership_id: &Uuid,
+    dto: &EditMemberDto,
+    group_id: &str,
+    group_domain: &str,
+    db: X,
+    user: &User,
+) -> AppResult<()>
+where
+    X: sqlx::Acquire<'x, Database = sqlx::Postgres>,
+{
+    let mut txn = db.begin().await?;
+
+    let old = require_one(membership_id, &mut *txn).await?;
+    let old = EditMemberDto {
+        from: BrowserDateDto(old.from),
+        until: BrowserDateDto(old.until),
+    };
+
+    let mut query = sqlx::QueryBuilder::new("UPDATE direct_memberships SET");
+    let mut changed = HashMap::new();
+
+    update_if_changed!(changed, query, from, old, dto);
+    update_if_changed!(changed, query, until, old, dto);
+
+    if !changed.is_empty() {
+        query
+            .push(" WHERE id = ")
+            .push_bind(membership_id)
+            .push(" AND group_id  = ")
+            .push_bind(group_id)
+            .push(" AND group_domain = ")
+            .push_bind(group_domain)
+            .build()
+            .execute(&mut *txn)
+            .await?;
+
+        audit_logs::add_entry(
+            ActionKind::Update,
+            TargetKind::Membership,
+            // FIXME: consider using membership_id as target_id
+            format!("{}@{}", group_id, group_domain),
+            user.username(),
+            audit_log_details_for_update!(changed),
+            &mut *txn,
+        )
+        .await?;
+
+        txn.commit().await?;
+    }
+
+    Ok(())
 }
 
 // membership_id is enough, but group id/domain is good just to double-check

--- a/src/web/groups/members.rs
+++ b/src/web/groups/members.rs
@@ -303,8 +303,11 @@ async fn add_member<'v>(
     // TODO: anti-CSRF
 
     if let Some(until) = form.value.as_ref().map(|dto| dto.until.0) {
-        if !groups::members::check_appointment_bounds(&until, id, domain, perms, db.inner()).await?
-        {
+        let is_within_appointment_bounds =
+            groups::members::check_appointment_bounds(&until, id, domain, perms, db.inner())
+                .await?;
+
+        if !is_within_appointment_bounds {
             // ok, not authorized (but 403 would be confusing, so we forge a form error)
             let error = form::Error::validation("Too far in the future").with_name("until");
             form.context.push_error(error);
@@ -475,15 +478,16 @@ async fn edit_member<'v>(
     .await?;
 
     if let Some(until) = form.value.as_ref().map(|dto| dto.until.0) {
-        if !groups::members::check_appointment_bounds(
+        let is_within_appointment_bounds = groups::members::check_appointment_bounds(
             &until,
             &group_id,
             &group_domain,
             perms,
             db.inner(),
         )
-        .await?
-        {
+        .await?;
+
+        if !is_within_appointment_bounds {
             // ok, not authorized (but 403 would be confusing, so we forge a form error)
             let error = form::Error::validation("Too far in the future").with_name("until");
             form.context.push_error(error);

--- a/src/web/groups/members.rs
+++ b/src/web/groups/members.rs
@@ -2,8 +2,9 @@ use chrono::{Datelike, Local, NaiveDate};
 use log::*;
 use rinja::Template;
 use rocket::{
-    State,
+    Responder, State, State,
     form::{self, Contextual, Form},
+    http::Header,
     response::{Redirect, content::RawHtml},
     uri,
 };
@@ -11,7 +12,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::{
-    dto::groups::{AddMemberDto, AddSubgroupDto},
+    dto::groups::{AddMemberDto, AddSubgroupDto, EditMemberDto},
     errors::{AppError, AppResult},
     guards::{context::PageContext, headers::HxRequest, perms::PermsEvaluator, user::User},
     models::{GroupMember, GroupRef, SimpleGroup, Subgroup},
@@ -19,7 +20,7 @@ use crate::{
     resolver::IdentityResolver,
     routing::RouteTree,
     services::groups::{self, AuthorityInGroup},
-    web::{Either, RenderedTemplate},
+    web::{Either, RenderedTemplate, groups::GroupDetailsView},
 };
 
 pub fn routes() -> RouteTree {
@@ -27,6 +28,8 @@ pub fn routes() -> RouteTree {
         list_members,
         add_subgroup,
         add_member,
+        edit_member_form,
+        edit_member,
         remove_subgroup,
         remove_member,
         get_membership_details
@@ -79,6 +82,35 @@ struct PartialMembershipDetailsView<'r> {
     username: &'r str,
     paths: Vec<Vec<GroupRef>>, // empty => not indirect member (but not <=!)
     is_direct_member: bool,    // false doesn't mean indirect! might be none
+}
+
+#[derive(Template)]
+#[template(path = "groups/members/edit.html.j2")]
+struct MemberEditView<'r, 'f, 'v> {
+    ctx: PageContext,
+    member: GroupMember,
+    group_id: &'r str,
+    group_domain: &'r str,
+    member_edit_form: &'f form::Context<'v>,
+}
+
+#[derive(Template)]
+#[template(path = "groups/members/edited.html.j2")]
+struct MemberEditedView<'r> {
+    ctx: PageContext,
+    member: GroupMember,
+    group_id: &'r str,
+    group_domain: &'r str,
+    show_indirect: bool,
+    can_manage: bool,
+    is_future_member: bool,
+}
+
+#[derive(Responder)]
+pub enum EditMemberResponse {
+    SuccessPartial(RenderedTemplate, Header<'static>, Header<'static>),
+    SuccessFullPage(Redirect),
+    Invalid(RenderedTemplate),
 }
 
 #[rocket::get("/group/<domain>/<id>/members?<show_indirect>")]
@@ -357,6 +389,162 @@ async fn add_member<'v>(
 
             let target = uri!(super::group_details(id = id, domain = domain));
             Ok(Either::Right(Redirect::to(target)))
+        }
+    }
+}
+
+#[rocket::get("/group/<domain>/<id>/edit/<member>")]
+#[allow(clippy::too_many_arguments)]
+async fn edit_member_form<'v>(
+    id: &str,
+    domain: &str,
+    member: Uuid,
+    db: &State<PgPool>,
+    ctx: PageContext,
+    perms: &PermsEvaluator,
+    user: User,
+    partial: Option<HxRequest<'_>>,
+) -> AppResult<Either<RenderedTemplate, Redirect>> {
+    if partial.is_none() {
+        // we only know how to render a form, not a full page;
+        // redirect to group details
+
+        let target = uri!(super::group_details(id = id, domain = domain));
+        return Ok(Either::Right(Redirect::to(target)));
+    }
+
+    groups::details::require_authority(
+        AuthorityInGroup::ManageMembers,
+        id,
+        domain,
+        db.inner(),
+        perms,
+        &user,
+    )
+    .await?;
+
+    let member = groups::members::require_one(&member, db.inner()).await?;
+
+    let template = MemberEditView {
+        ctx,
+        member,
+        group_id: id,
+        group_domain: domain,
+        member_edit_form: &form::Context::default(),
+    };
+
+    Ok(Either::Left(RawHtml(template.render()?)))
+}
+
+#[rocket::patch("/group/<domain>/<id>/edit/<member>?<show_indirect>", data = "<form>")]
+#[allow(clippy::too_many_arguments)]
+async fn edit_member<'v>(
+    id: &str,
+    domain: &str,
+    member: Uuid,
+    show_indirect: bool,
+    form: Form<Contextual<'v, EditMemberDto>>,
+    db: &State<PgPool>,
+    resolver: &State<Option<IdentityResolver>>,
+    ctx: PageContext,
+    perms: &PermsEvaluator,
+    user: User,
+    partial: Option<HxRequest<'_>>,
+) -> AppResult<EditMemberResponse> {
+    let authority = groups::details::require_authority(
+        AuthorityInGroup::ManageMembers,
+        id,
+        domain,
+        db.inner(),
+        perms,
+        &user,
+    )
+    .await?;
+
+    if let Some(dto) = &form.value {
+        groups::members::update(&member, dto, id, domain, db.inner(), &user).await?;
+
+        let mut changed = groups::members::require_one(&member, db.inner()).await?;
+
+        if partial.is_some() {
+            if let Some(resolver) = resolver.as_ref() {
+                changed.display_name = resolver.resolve_one(&changed.username).await?;
+            }
+
+            let is_future_member = changed.from > Local::now().date_naive();
+
+            let template = MemberEditedView {
+                ctx,
+                group_id: id,
+                group_domain: domain,
+                member: changed,
+                show_indirect,
+                is_future_member,
+                can_manage: authority >= AuthorityInGroup::ManageMembers,
+            };
+
+            Ok(EditMemberResponse::SuccessPartial(
+                RawHtml(template.render()?),
+                Header::new("HX-Retarget", format!("#member-{}", member)),
+                Header::new("HX-Reswap", "outerHTML"),
+            ))
+        } else {
+            let target = uri!(super::group_details(id = id, domain = domain));
+            return Ok(EditMemberResponse::SuccessFullPage(Redirect::to(target)));
+        }
+    } else {
+        debug!("Edit member form errors: {:?}", &form.context);
+
+        if partial.is_some() {
+            let member = groups::members::require_one(&member, db.inner()).await?;
+
+            // Find a way to not reset the form on error
+            let template = MemberEditView {
+                ctx,
+                member,
+                group_id: id,
+                group_domain: domain,
+                member_edit_form: &form.context,
+            };
+
+            return Ok(EditMemberResponse::Invalid(RawHtml(template.render()?)));
+        } else {
+            let group = groups::details::require_one(id, domain, db.inner()).await?;
+
+            let relevance = groups::details::get_relevance(id, domain, db.inner(), perms, &user)
+                .await?
+                .ok_or_else(|| AppError::NoSuchGroup(id.to_owned(), domain.to_owned()))?;
+
+            let permissible_groups =
+                groups::list::list_all_permissible_sorted(&ctx.lang, db.inner(), perms, &user)
+                    .await?;
+
+            let assignable_permissions =
+                groups::permissions::get_all_assignable(perms, db.inner()).await?;
+            let assignable_tags = groups::tags::get_all_assignable(perms, db.inner()).await?;
+
+            let empty_form = form::Context::default();
+
+            let template = GroupDetailsView {
+                ctx,
+                group,
+                relevance,
+                add_subgroup_form: &empty_form,
+                add_subgroup_success: None,
+                add_member_form: &empty_form,
+                add_member_success: None,
+                assign_permission_form: &empty_form,
+                assign_permission_success: None,
+                assign_tag_form: &empty_form,
+                assign_tag_success: None,
+                edit_form: &empty_form,
+                edit_modal_open: true,
+                permissible_groups,
+                assignable_permissions,
+                assignable_tags,
+            };
+
+            return Ok(EditMemberResponse::Invalid(RawHtml(template.render()?)));
         }
     }
 }

--- a/src/web/groups/members.rs
+++ b/src/web/groups/members.rs
@@ -393,162 +393,6 @@ async fn add_member<'v>(
     }
 }
 
-#[rocket::get("/group/<domain>/<id>/edit/<member>")]
-#[allow(clippy::too_many_arguments)]
-async fn edit_member_form<'v>(
-    id: &str,
-    domain: &str,
-    member: Uuid,
-    db: &State<PgPool>,
-    ctx: PageContext,
-    perms: &PermsEvaluator,
-    user: User,
-    partial: Option<HxRequest<'_>>,
-) -> AppResult<Either<RenderedTemplate, Redirect>> {
-    if partial.is_none() {
-        // we only know how to render a form, not a full page;
-        // redirect to group details
-
-        let target = uri!(super::group_details(id = id, domain = domain));
-        return Ok(Either::Right(Redirect::to(target)));
-    }
-
-    groups::details::require_authority(
-        AuthorityInGroup::ManageMembers,
-        id,
-        domain,
-        db.inner(),
-        perms,
-        &user,
-    )
-    .await?;
-
-    let member = groups::members::require_one(&member, db.inner()).await?;
-
-    let template = MemberEditView {
-        ctx,
-        member,
-        group_id: id,
-        group_domain: domain,
-        member_edit_form: &form::Context::default(),
-    };
-
-    Ok(Either::Left(RawHtml(template.render()?)))
-}
-
-#[rocket::patch("/group/<domain>/<id>/edit/<member>?<show_indirect>", data = "<form>")]
-#[allow(clippy::too_many_arguments)]
-async fn edit_member<'v>(
-    id: &str,
-    domain: &str,
-    member: Uuid,
-    show_indirect: bool,
-    form: Form<Contextual<'v, EditMemberDto>>,
-    db: &State<PgPool>,
-    resolver: &State<Option<IdentityResolver>>,
-    ctx: PageContext,
-    perms: &PermsEvaluator,
-    user: User,
-    partial: Option<HxRequest<'_>>,
-) -> AppResult<EditMemberResponse> {
-    let authority = groups::details::require_authority(
-        AuthorityInGroup::ManageMembers,
-        id,
-        domain,
-        db.inner(),
-        perms,
-        &user,
-    )
-    .await?;
-
-    if let Some(dto) = &form.value {
-        groups::members::update(&member, dto, id, domain, db.inner(), &user).await?;
-
-        let mut changed = groups::members::require_one(&member, db.inner()).await?;
-
-        if partial.is_some() {
-            if let Some(resolver) = resolver.as_ref() {
-                changed.display_name = resolver.resolve_one(&changed.username).await?;
-            }
-
-            let is_future_member = changed.from > Local::now().date_naive();
-
-            let template = MemberEditedView {
-                ctx,
-                group_id: id,
-                group_domain: domain,
-                member: changed,
-                show_indirect,
-                is_future_member,
-                can_manage: authority >= AuthorityInGroup::ManageMembers,
-            };
-
-            Ok(EditMemberResponse::SuccessPartial(
-                RawHtml(template.render()?),
-                Header::new("HX-Retarget", format!("#member-{}", member)),
-                Header::new("HX-Reswap", "outerHTML"),
-            ))
-        } else {
-            let target = uri!(super::group_details(id = id, domain = domain));
-            return Ok(EditMemberResponse::SuccessFullPage(Redirect::to(target)));
-        }
-    } else {
-        debug!("Edit member form errors: {:?}", &form.context);
-
-        if partial.is_some() {
-            let member = groups::members::require_one(&member, db.inner()).await?;
-
-            // Find a way to not reset the form on error
-            let template = MemberEditView {
-                ctx,
-                member,
-                group_id: id,
-                group_domain: domain,
-                member_edit_form: &form.context,
-            };
-
-            return Ok(EditMemberResponse::Invalid(RawHtml(template.render()?)));
-        } else {
-            let group = groups::details::require_one(id, domain, db.inner()).await?;
-
-            let relevance = groups::details::get_relevance(id, domain, db.inner(), perms, &user)
-                .await?
-                .ok_or_else(|| AppError::NoSuchGroup(id.to_owned(), domain.to_owned()))?;
-
-            let permissible_groups =
-                groups::list::list_all_permissible_sorted(&ctx.lang, db.inner(), perms, &user)
-                    .await?;
-
-            let assignable_permissions =
-                groups::permissions::get_all_assignable(perms, db.inner()).await?;
-            let assignable_tags = groups::tags::get_all_assignable(perms, db.inner()).await?;
-
-            let empty_form = form::Context::default();
-
-            let template = GroupDetailsView {
-                ctx,
-                group,
-                relevance,
-                add_subgroup_form: &empty_form,
-                add_subgroup_success: None,
-                add_member_form: &empty_form,
-                add_member_success: None,
-                assign_permission_form: &empty_form,
-                assign_permission_success: None,
-                assign_tag_form: &empty_form,
-                assign_tag_success: None,
-                edit_form: &empty_form,
-                edit_modal_open: true,
-                permissible_groups,
-                assignable_permissions,
-                assignable_tags,
-            };
-
-            return Ok(EditMemberResponse::Invalid(RawHtml(template.render()?)));
-        }
-    }
-}
-
 #[rocket::delete("/group/<parent_domain>/<parent_id>/subgroup/<child_domain>/<child_id>")]
 #[allow(clippy::too_many_arguments)]
 async fn remove_subgroup<'v>(
@@ -590,6 +434,168 @@ async fn remove_subgroup<'v>(
         Ok(Either::Right(Redirect::to(target)))
     }
 }
+
+#[rocket::get("/group-membership/<id>/edit")]
+#[allow(clippy::too_many_arguments)]
+async fn edit_member_form<'v>(
+    id: Uuid,
+    db: &State<PgPool>,
+    ctx: PageContext,
+    perms: &PermsEvaluator,
+    user: User,
+    partial: Option<HxRequest<'_>>,
+) -> AppResult<Either<RenderedTemplate, Redirect>> {
+    let (group_id, group_domain) = groups::members::get_membership_group(&id, db.inner())
+        .await?
+        .ok_or(AppError::NoSuchMembership(id.to_string()))?;
+
+    if partial.is_none() {
+        // we only know how to render a form, not a full page;
+        // redirect to group details
+
+        let target = uri!(super::group_details(id = group_id, domain = group_domain));
+        return Ok(Either::Right(Redirect::to(target)));
+    }
+
+    groups::details::require_authority(
+        AuthorityInGroup::ManageMembers,
+        &group_id,
+        &group_domain,
+        db.inner(),
+        perms,
+        &user,
+    )
+    .await?;
+
+    let member = groups::members::require_one(&id, db.inner()).await?;
+
+    let template = MemberEditView {
+        ctx,
+        member,
+        group_id: &group_id,
+        group_domain: &group_domain,
+        member_edit_form: &form::Context::default(),
+    };
+
+    Ok(Either::Left(RawHtml(template.render()?)))
+}
+
+#[rocket::patch("/group-membership/<id>?<show_indirect>", data = "<form>")]
+#[allow(clippy::too_many_arguments)]
+async fn edit_member<'v>(
+    id: Uuid,
+    show_indirect: bool,
+    form: Form<Contextual<'v, EditMemberDto>>,
+    db: &State<PgPool>,
+    resolver: &State<Option<IdentityResolver>>,
+    ctx: PageContext,
+    perms: &PermsEvaluator,
+    user: User,
+    partial: Option<HxRequest<'_>>,
+) -> AppResult<EditMemberResponse> {
+    let (group_id, group_domain) = groups::members::get_membership_group(&id, db.inner())
+        .await?
+        .ok_or(AppError::NoSuchMembership(id.to_string()))?;
+
+    let authority = groups::details::require_authority(
+        AuthorityInGroup::ManageMembers,
+        &group_id,
+        &group_domain,
+        db.inner(),
+        perms,
+        &user,
+    )
+    .await?;
+
+    if let Some(dto) = &form.value {
+        groups::members::update(&id, dto, &group_id, &group_domain, db.inner(), &user).await?;
+
+        let mut changed = groups::members::require_one(&id, db.inner()).await?;
+
+        if partial.is_some() {
+            if let Some(resolver) = resolver.as_ref() {
+                changed.display_name = resolver.resolve_one(&changed.username).await?;
+            }
+
+            let is_future_member = changed.from > Local::now().date_naive();
+
+            let template = MemberEditedView {
+                ctx,
+                group_id: &group_id,
+                group_domain: &group_domain,
+                member: changed,
+                show_indirect,
+                is_future_member,
+                can_manage: authority >= AuthorityInGroup::ManageMembers,
+            };
+
+            Ok(EditMemberResponse::SuccessPartial(
+                RawHtml(template.render()?),
+                Header::new("HX-Retarget", format!("#member-{}", id)),
+                Header::new("HX-Reswap", "outerHTML"),
+            ))
+        } else {
+            let target = uri!(super::group_details(id = group_id, domain = group_domain));
+            return Ok(EditMemberResponse::SuccessFullPage(Redirect::to(target)));
+        }
+    } else {
+        debug!("Edit member form errors: {:?}", &form.context);
+
+        if partial.is_some() {
+            let member = groups::members::require_one(&id, db.inner()).await?;
+
+            // Find a way to not reset the form on error
+            let template = MemberEditView {
+                ctx,
+                member,
+                group_id: &group_id,
+                group_domain: &group_domain,
+                member_edit_form: &form.context,
+            };
+
+            return Ok(EditMemberResponse::Invalid(RawHtml(template.render()?)));
+        } else {
+            let group = groups::details::require_one(&group_id, &group_domain, db.inner()).await?;
+
+            let relevance = groups::details::get_relevance(&group_id, &group_domain, db.inner(), perms, &user)
+                .await?
+                .ok_or_else(|| AppError::NoSuchGroup(group_id, group_domain))?;
+
+            let permissible_groups =
+                groups::list::list_all_permissible_sorted(&ctx.lang, db.inner(), perms, &user)
+                    .await?;
+
+            let assignable_permissions =
+                groups::permissions::get_all_assignable(perms, db.inner()).await?;
+            let assignable_tags = groups::tags::get_all_assignable(perms, db.inner()).await?;
+
+            let empty_form = form::Context::default();
+
+            let template = GroupDetailsView {
+                ctx,
+                group,
+                relevance,
+                add_subgroup_form: &empty_form,
+                add_subgroup_success: None,
+                add_member_form: &empty_form,
+                add_member_success: None,
+                assign_permission_form: &empty_form,
+                assign_permission_success: None,
+                assign_tag_form: &empty_form,
+                assign_tag_success: None,
+                edit_form: &empty_form,
+                edit_modal_open: true,
+                permissible_groups,
+                assignable_permissions,
+                assignable_tags,
+            };
+
+            return Ok(EditMemberResponse::Invalid(RawHtml(template.render()?)));
+        }
+    }
+}
+
+
 
 #[rocket::delete("/group-membership/<id>")]
 async fn remove_member<'v>(

--- a/src/web/groups/members.rs
+++ b/src/web/groups/members.rs
@@ -303,45 +303,12 @@ async fn add_member<'v>(
     // TODO: anti-CSRF
 
     if let Some(until) = form.value.as_ref().map(|dto| dto.until.0) {
-        let exempt = groups::tags::is_tagged_with(
-            id,
-            domain,
-            crate::HIVE_SYSTEM_ID,
-            "appointment-bounds-exemption",
-            db.inner(),
-        )
-        .await?;
-
-        if !exempt {
-            // the default limit for membership upper bound is either 31/Dec of the current
-            // year or 30/Jun of the following year, whichever is closer but more
-            // than 6 months away
-            let today = Local::now().date_naive();
-            let limit = if today < NaiveDate::from_ymd_opt(today.year(), 6, 30).unwrap() {
-                NaiveDate::from_ymd_opt(today.year(), 12, 31).unwrap()
-            } else {
-                NaiveDate::from_ymd_opt(today.year() + 1, 6, 30).unwrap()
-            };
-
-            if until > limit {
-                // outside of base case, so need special permission
-
-                let years_diff = until.year() - today.year();
-                let months_diff = until.month() as i32 - today.month() as i32;
-                let mut total_months = years_diff * 12 + months_diff;
-                if until.day() > today.day() {
-                    total_months += 1; // adjust rounding up
-                }
-                let total_months = total_months.clamp(0, u8::MAX as _) as u8;
-
-                let min = HivePermission::LongTermAppointment(UpperBoundScope::UpTo(total_months));
-                if !perms.satisfies(min).await? {
-                    // ok, not authorized (but 403 would be confusing, so we forge a form error)
-                    let error = form::Error::validation("Too far in the future").with_name("until");
-                    form.context.push_error(error);
-                    form.value = None;
-                }
-            }
+        if !groups::members::check_appointment_bounds(&until, id, domain, perms, db.inner()).await?
+        {
+            // ok, not authorized (but 403 would be confusing, so we forge a form error)
+            let error = form::Error::validation("Too far in the future").with_name("until");
+            form.context.push_error(error);
+            form.value = None;
         }
     }
 
@@ -485,7 +452,7 @@ async fn edit_member_form<'v>(
 async fn edit_member<'v>(
     id: Uuid,
     show_indirect: bool,
-    form: Form<Contextual<'v, EditMemberDto>>,
+    mut form: Form<Contextual<'v, EditMemberDto>>,
     db: &State<PgPool>,
     resolver: &State<Option<IdentityResolver>>,
     ctx: PageContext,
@@ -506,6 +473,23 @@ async fn edit_member<'v>(
         &user,
     )
     .await?;
+
+    if let Some(until) = form.value.as_ref().map(|dto| dto.until.0) {
+        if !groups::members::check_appointment_bounds(
+            &until,
+            &group_id,
+            &group_domain,
+            perms,
+            db.inner(),
+        )
+        .await?
+        {
+            // ok, not authorized (but 403 would be confusing, so we forge a form error)
+            let error = form::Error::validation("Too far in the future").with_name("until");
+            form.context.push_error(error);
+            form.value = None;
+        }
+    }
 
     if let Some(dto) = &form.value {
         groups::members::update(&id, dto, &group_id, &group_domain, db.inner(), &user).await?;
@@ -557,9 +541,10 @@ async fn edit_member<'v>(
         } else {
             let group = groups::details::require_one(&group_id, &group_domain, db.inner()).await?;
 
-            let relevance = groups::details::get_relevance(&group_id, &group_domain, db.inner(), perms, &user)
-                .await?
-                .ok_or_else(|| AppError::NoSuchGroup(group_id, group_domain))?;
+            let relevance =
+                groups::details::get_relevance(&group_id, &group_domain, db.inner(), perms, &user)
+                    .await?
+                    .ok_or_else(|| AppError::NoSuchGroup(group_id, group_domain))?;
 
             let permissible_groups =
                 groups::list::list_all_permissible_sorted(&ctx.lang, db.inner(), perms, &user)
@@ -594,8 +579,6 @@ async fn edit_member<'v>(
         }
     }
 }
-
-
 
 #[rocket::delete("/group-membership/<id>")]
 async fn remove_member<'v>(

--- a/templates/groups/details.html.j2
+++ b/templates/groups/details.html.j2
@@ -181,10 +181,14 @@
     {% endif %}
 </article>
 
+{% if relevance.authority >= AuthorityInGroup::ManageMembers %}
+<dialog id="edit-member">
+</dialog>
 {% if relevance.authority == AuthorityInGroup::FullyAuthorized %}
 {% include "edit.html.j2" %}
 {% if group.domain != crate::HIVE_INTERNAL_DOMAIN %}
 {% include "delete.html.j2" %}
+{% endif %}
 {% endif %}
 {% endif %}
 {% endblock content %}

--- a/templates/groups/members/add-member.html.j2
+++ b/templates/groups/members/add-member.html.j2
@@ -13,11 +13,20 @@
     <template>
         {% let is_future_member = member.from > chrono::Local::now().date_naive() %}
         <tbody hx-swap-oob="beforeend:#group-members-table[data-with-indirect=false] tbody">
-            {% if is_future_member %}
+            {% if let Some(id) = member.id %}
+                {% if is_future_member %}
+            <tr id=member-{{ id }} class="secondary">
+                {% else %}
+            <tr id=member-{{ id }}>
+                {% endif %}
+            {% else %}
+                {% if is_future_member %}
             <tr class="secondary">
                 {% else %}
             <tr>
                 {% endif %}
+            {% endif %}
+
 
                 {% let show_indirect = false %}
                 {% let can_manage = true %}

--- a/templates/groups/members/edit.html.j2
+++ b/templates/groups/members/edit.html.j2
@@ -1,0 +1,31 @@
+{%- import "utils.html.j2" as utils -%}
+
+<article>
+    <h2>{{ ctx.t("groups.members.edit.title") }}</h2>
+    {% if let Some(id) = member.id %}
+    <form id="edit-member-form" onsubmit="event.preventDefault()" hx-patch="/group/{{ group_domain }}/{{ group_id }}/edit/{{ id }}" hx-target="#edit-member">
+        <div class="grid">
+            <label>
+                {{ ctx.t("groups.members.add.member.field.from.label") }}
+                <input type="date" value="{{ member.from }}" {% call utils::field(member_edit_form, "from") %}
+                    required />
+                <small id="member-from-tip">{{ ctx.t("groups.members.add.member.field.from.tip") }}</small>
+            </label>
+            <label>
+                {{ ctx.t("groups.members.add.member.field.until.label") }}
+                <input type="date" value="{{ member.until }}" {% call utils::field(member_edit_form, "until") %}
+                    required />
+                <small id="member-until-tip">{{ ctx.t("groups.members.add.member.field.until.tip") }}</small>
+            </label>
+        </div>
+    </form>
+    {% endif %}
+    <footer>
+        <button form="edit-member-form" type="reset" class="secondary" onclick="closeModal('edit-member')">
+            {{ ctx.t("control.cancel") }}
+        </button>
+        <button form="edit-member-form" id="edit-member-submit">
+            {{ ctx.t("control.save") }}
+        </button>
+    </footer>
+</article>

--- a/templates/groups/members/edit.html.j2
+++ b/templates/groups/members/edit.html.j2
@@ -3,7 +3,7 @@
 <article>
     <h2>{{ ctx.t("groups.members.edit.title") }}</h2>
     {% if let Some(id) = member.id %}
-    <form id="edit-member-form" onsubmit="event.preventDefault()" hx-patch="/group/{{ group_domain }}/{{ group_id }}/edit/{{ id }}" hx-target="#edit-member">
+    <form id="edit-member-form" onsubmit="event.preventDefault()" hx-patch="/group-membership/{{ id }}" hx-target="#edit-member">
         <div class="grid">
             <label>
                 {{ ctx.t("groups.members.add.member.field.from.label") }}

--- a/templates/groups/members/edited.html.j2
+++ b/templates/groups/members/edited.html.j2
@@ -1,0 +1,9 @@
+{% if let Some(id) = member.id %}
+<tr id="member-{{ id }}">
+    {% include "member-cells.html.j2" %}
+</tr>
+{% endif %}
+
+<div hx-swap-oob="innerHTML:#edit-member">
+    <script>closeModal('edit-member')</script>
+</div>

--- a/templates/groups/members/list.html.j2
+++ b/templates/groups/members/list.html.j2
@@ -35,20 +35,28 @@
             </td>
         </tr>
         {% for subgroup in subgroups %}
-        <tr>
-            {% include "subgroup-cells.html.j2" %}
-        </tr>
+            <tr>
+                {% include "subgroup-cells.html.j2" %}
+            </tr>
         {% endfor %}
         {% for member in members %}
-        {% let is_future_member = member.from > chrono::Local::now().date_naive() %}
-        {% if is_future_member %}
-        <tr class="secondary">
+            {% let is_future_member = member.from > chrono::Local::now().date_naive() %}
+            {% if let Some(id) = member.id %}
+                {% if is_future_member %}
+                    <tr id=member-{{ id }} class="secondary">
+                {% else %}
+                    <tr id=member-{{ id }}>
+                {% endif %}
             {% else %}
-        <tr>
+                {% if is_future_member %}
+                    <tr class="secondary">
+                {% else %}
+                    <tr>
+                {% endif %}
             {% endif %}
 
-            {% include "member-cells.html.j2" %}
-        </tr>
+                {% include "member-cells.html.j2" %}
+            </tr>
         {% endfor %}
     </tbody>
 </table>

--- a/templates/groups/members/member-cells.html.j2
+++ b/templates/groups/members/member-cells.html.j2
@@ -51,7 +51,7 @@
 {% if can_manage && !show_indirect %}
 <td>
     {% if let Some(id) = member.id %}
-    <button class="secondary" hx-get="/group/{{ group_domain }}/{{ group_id }}/edit/{{ id }}" hx-target="#edit-member" hx-swap="innerHTML" onclick="openModal('edit-member')"
+    <button class="secondary" hx-get="/group-membership/{{ id }}/edit" hx-target="#edit-member" hx-swap="innerHTML" onclick="openModal('edit-member')"
         data-tooltip='{{ ctx.t("groups.members.list.action.edit.tooltip") }}' data-placement="left">
         <span class="material-icons">edit</span>
     </button>

--- a/templates/groups/members/member-cells.html.j2
+++ b/templates/groups/members/member-cells.html.j2
@@ -51,6 +51,10 @@
 {% if can_manage && !show_indirect %}
 <td>
     {% if let Some(id) = member.id %}
+    <button class="secondary" hx-get="/group/{{ group_domain }}/{{ group_id }}/edit/{{ id }}" hx-target="#edit-member" hx-swap="innerHTML" onclick="openModal('edit-member')"
+        data-tooltip='{{ ctx.t("groups.members.list.action.edit.tooltip") }}' data-placement="left">
+        <span class="material-icons">edit</span>
+    </button>
     <button class="btn-danger" data-tooltip='{{ ctx.t("groups.members.list.action.delete.tooltip") }}'
         data-placement="left" hx-delete="/group-membership/{{ id }}" hx-swap="delete" hx-target="closest tr"
         hx-confirm='{{ ctx.t1("groups.members.list.action.delete.direct-member.confirm", member.username) }}'>

--- a/templates/utils.html.j2
+++ b/templates/utils.html.j2
@@ -20,10 +20,11 @@ value='{{ value.unwrap_or(default) }}'
 {%- endmacro field %}
 
 
-{% macro checkbox(form, name) -%}
+{% macro checkbox_with_default(form, name, default) -%}
 type="checkbox"
 name="{{ name }}"
-{%- if form.field_value(name).is_some() -%}
+{%- let value = form.field_value(name) -%}
+{%- if value.is_some() || (value.is_none() && default) -%}
 checked{{ ' ' }}
 {%- endif -%}
 {%- if form.field_errors(name).next().is_some() -%}
@@ -31,6 +32,11 @@ aria-invalid="true"
 {%- else if form.errors().next().is_some() -%}
 aria-invalid="false"
 {%- endif -%}
+{%- endmacro checkbox_with_default %}
+
+
+{% macro checkbox(form, name) -%}
+{%- call checkbox_with_default(form, name, false) -%}
 {%- endmacro checkbox %}
 
 


### PR DESCRIPTION
Adds a form in a modal that allows manager to change the start and end date. It also updates the update_if_changed macro to make it usable for other types. I have tried to adhere to how the edit group functionality work. Including how it handles responses and how it opens and closes the modal. I decided to only have one modal for editing members and update the content of it rather than generating one for each member. It felt inefficient to generate such large quantities of html for a function that probably wont be used that often. 

Resolves #5 