### PR TITLE
feat: add logs page

### DIFF
--- a/locales/hive.yaml
+++ b/locales/hive.yaml
@@ -1255,3 +1255,75 @@ user.settings.field.integration_gworkspace_personal-email.tip:
 user.settings.title:
   en: My Settings
   sv: Mina inställningar
+logs.details.control.action.label:
+  en: Action
+  sv: Handling
+logs.details.control.action.option.any:
+  en: All Actions
+  sv: Alla Handlingar
+logs.details.control.action.option.create:
+  en: Create
+  sv: Skapa
+logs.details.control.action.option.update:
+  en: Update
+  sv: Updatera
+logs.details.control.action.option.delete:
+  en: Delete
+  sv: Radera
+logs.details.control.action.option.impersonate:
+  en: Impersonate
+  sv: Imitera
+logs.details.control.target.label:
+  en: Target
+  sv: Mål
+logs.details.control.target.option.any:
+  en: All Targets
+  sv: Alla Mål
+logs.details.control.target.option.group:
+  en: Group
+  sv: Grupp
+logs.details.control.target.option.membership:
+  en: Membership
+  sv: Medlemskap
+logs.details.control.target.option.system:
+  en: System
+  sv: System
+logs.details.control.target.option.apitoken:
+  en: ApiToken
+  sv: ApiToken
+logs.details.control.target.option.tag:
+  en: Tag
+  sv: Tag
+logs.details.control.target.option.tagassignment:
+  en: TagAssignment
+  sv: TagTilldelning
+logs.details.control.target.option.permission:
+  en: Permission
+  sv: Rättighet
+logs.details.control.target.option.permissionassignment:
+  en: PermissionAssignment
+  sv: RättighetsTilldelning
+logs.details.control.target.option.user:
+  en: User
+  sv: Användare
+logs.details.control.actor.label:
+  en: Actor
+  sv: Aktör
+logs.details.control.actor.option.any:
+  en: All Actors
+  sv: Alla Aktör
+logs.details.control.id.label:
+  en: ID
+  sv: ID
+logs.details.control.id.option.any:
+  en: All IDs
+  sv: Alla IDn
+logs.details.control.from.label:
+  en: From
+  sv: Från
+logs.details.control.until.label:
+  en: Until
+  sv: Fram till
+logs.details.control.order.label:
+  en: Chronological
+  sv: Kronologisk

--- a/locales/hive.yaml
+++ b/locales/hive.yaml
@@ -644,6 +644,78 @@ indicator.datetime.never:
 listing.n-results:
   en: Showing a total of %{x} results.
   sv: Visar totalt %{x} resultat.
+logs.list.control.action.label:
+  en: Action
+  sv: Handling
+logs.list.control.action.option.any:
+  en: All Actions
+  sv: Alla Handlingar
+logs.list.control.action.option.create:
+  en: Create
+  sv: Skapa
+logs.list.control.action.option.delete:
+  en: Delete
+  sv: Radera
+logs.list.control.action.option.impersonate:
+  en: Impersonate
+  sv: Imitera
+logs.list.control.action.option.update:
+  en: Update
+  sv: Updatera
+logs.list.control.actor.label:
+  en: Actor
+  sv: Aktör
+logs.list.control.actor.option.any:
+  en: All Actors
+  sv: Alla Aktör
+logs.list.control.from.label:
+  en: From
+  sv: Från
+logs.list.control.id.label:
+  en: ID
+  sv: ID
+logs.list.control.id.option.any:
+  en: All IDs
+  sv: Alla ID:n
+logs.list.control.order.label:
+  en: Chronological
+  sv: Kronologisk
+logs.list.control.target.label:
+  en: Target
+  sv: Mål
+logs.list.control.target.option.any:
+  en: All Targets
+  sv: Alla Mål
+logs.list.control.target.option.api-token:
+  en: API Token
+  sv: API-nyckel
+logs.list.control.target.option.group:
+  en: Group
+  sv: Grupp
+logs.list.control.target.option.membership:
+  en: Membership
+  sv: Medlemskap
+logs.list.control.target.option.permission:
+  en: Permission
+  sv: Rättighet
+logs.list.control.target.option.permission-assignment:
+  en: Permission Assignment
+  sv: Rättighets Tilldelning
+logs.list.control.target.option.system:
+  en: System
+  sv: System
+logs.list.control.target.option.tag:
+  en: Tag
+  sv: Tagg
+logs.list.control.target.option.tag-assignment:
+  en: Tag Assignment
+  sv: Tagg Tilldelning
+logs.list.control.target.option.user:
+  en: User
+  sv: Användare
+logs.list.control.until.label:
+  en: Until
+  sv: Fram till
 nav.lang.switch:
   en: Switch to Swedish
   sv: Byt till engelska
@@ -1255,75 +1327,3 @@ user.settings.field.integration_gworkspace_personal-email.tip:
 user.settings.title:
   en: My Settings
   sv: Mina inställningar
-logs.details.control.action.label:
-  en: Action
-  sv: Handling
-logs.details.control.action.option.any:
-  en: All Actions
-  sv: Alla Handlingar
-logs.details.control.action.option.create:
-  en: Create
-  sv: Skapa
-logs.details.control.action.option.update:
-  en: Update
-  sv: Updatera
-logs.details.control.action.option.delete:
-  en: Delete
-  sv: Radera
-logs.details.control.action.option.impersonate:
-  en: Impersonate
-  sv: Imitera
-logs.details.control.target.label:
-  en: Target
-  sv: Mål
-logs.details.control.target.option.any:
-  en: All Targets
-  sv: Alla Mål
-logs.details.control.target.option.group:
-  en: Group
-  sv: Grupp
-logs.details.control.target.option.membership:
-  en: Membership
-  sv: Medlemskap
-logs.details.control.target.option.system:
-  en: System
-  sv: System
-logs.details.control.target.option.apitoken:
-  en: ApiToken
-  sv: ApiToken
-logs.details.control.target.option.tag:
-  en: Tag
-  sv: Tag
-logs.details.control.target.option.tagassignment:
-  en: TagAssignment
-  sv: TagTilldelning
-logs.details.control.target.option.permission:
-  en: Permission
-  sv: Rättighet
-logs.details.control.target.option.permissionassignment:
-  en: PermissionAssignment
-  sv: RättighetsTilldelning
-logs.details.control.target.option.user:
-  en: User
-  sv: Användare
-logs.details.control.actor.label:
-  en: Actor
-  sv: Aktör
-logs.details.control.actor.option.any:
-  en: All Actors
-  sv: Alla Aktör
-logs.details.control.id.label:
-  en: ID
-  sv: ID
-logs.details.control.id.option.any:
-  en: All IDs
-  sv: Alla IDn
-logs.details.control.from.label:
-  en: From
-  sv: Från
-logs.details.control.until.label:
-  en: Until
-  sv: Fram till
-logs.details.control.order.label:
-  en: Chronological
-  sv: Kronologisk

--- a/locales/hive.yaml
+++ b/locales/hive.yaml
@@ -700,7 +700,7 @@ logs.list.control.target.option.permission:
   sv: Rättighet
 logs.list.control.target.option.permission-assignment:
   en: Permission Assignment
-  sv: Rättighets Tilldelning
+  sv: Rättighetstilldelning
 logs.list.control.target.option.system:
   en: System
   sv: System
@@ -709,7 +709,7 @@ logs.list.control.target.option.tag:
   sv: Tagg
 logs.list.control.target.option.tag-assignment:
   en: Tag Assignment
-  sv: Tagg Tilldelning
+  sv: Taggtilldelning
 logs.list.control.target.option.user:
   en: User
   sv: Användare

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -14,6 +14,7 @@ pub mod groups;
 pub mod permissions;
 pub mod systems;
 pub mod tags;
+pub mod logs;
 
 #[derive(sqlx::Type, Serialize, Clone, Copy)]
 #[sqlx(transparent)]

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -11,10 +11,10 @@ pub mod api_tokens;
 pub mod datetime;
 pub mod errors;
 pub mod groups;
+pub mod logs;
 pub mod permissions;
 pub mod systems;
 pub mod tags;
-pub mod logs;
 
 #[derive(sqlx::Type, Serialize, Clone, Copy)]
 #[sqlx(transparent)]

--- a/src/dto/datetime.rs
+++ b/src/dto/datetime.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 const BROWSER_DATE_TIME_FORMAT: &str = "%Y-%m-%dT%H:%M";
 const BROWSER_DATE_FORMAT: &str = "%Y-%m-%d";
 
-#[derive(sqlx::Type, Serialize)]
+#[derive(sqlx::Type, Serialize, Clone, Debug)]
 #[sqlx(transparent)]
 #[serde(transparent)]
 pub struct BrowserDateTimeDto(pub DateTime<Local>);

--- a/src/dto/logs.rs
+++ b/src/dto/logs.rs
@@ -1,7 +1,9 @@
 use sqlx::QueryBuilder;
 
 use crate::{
-    dto::datetime::BrowserDateTimeDto, models::{ActionKind, TargetKind}, sanitizers::SearchTerm
+    dto::datetime::BrowserDateTimeDto,
+    models::{ActionKind, TargetKind},
+    sanitizers::SearchTerm,
 };
 
 #[derive(Debug)]
@@ -12,7 +14,7 @@ pub struct LogsFilterDto<'r> {
     pub id: Option<&'r str>,
     pub from: Option<BrowserDateTimeDto>,
     pub until: Option<BrowserDateTimeDto>,
-    pub order: bool
+    pub order: bool,
 }
 
 impl LogsFilterDto<'_> {
@@ -25,12 +27,11 @@ impl LogsFilterDto<'_> {
             || self.until.is_some()
     }
 
-    pub fn query<'a>(&self, query: &mut QueryBuilder<'a, sqlx::Postgres>) {
+    pub fn apply<'a>(&self, query: &mut QueryBuilder<'a, sqlx::Postgres>) {
         let mut added = false;
         if self.any() {
             query.push(" WHERE");
         }
-
 
         if let Some(action) = &self.action {
             query.push(" action_kind = ");
@@ -84,6 +85,13 @@ impl LogsFilterDto<'_> {
             }
             query.push(" target_id LIKE ");
             query.push_bind(term);
+        }
+
+        query.push(" ORDER BY stamp ");
+        if self.order {
+            query.push("ASC");
+        } else {
+            query.push("DESC");
         }
     }
 }

--- a/src/dto/logs.rs
+++ b/src/dto/logs.rs
@@ -1,3 +1,4 @@
+use rocket::FromForm;
 use sqlx::QueryBuilder;
 
 use crate::{
@@ -6,7 +7,7 @@ use crate::{
     sanitizers::SearchTerm,
 };
 
-#[derive(Debug)]
+#[derive(FromForm, Debug)]
 pub struct LogsFilterDto<'r> {
     pub actor: Option<&'r str>,
     pub action: Option<ActionKind>,

--- a/src/dto/logs.rs
+++ b/src/dto/logs.rs
@@ -1,0 +1,89 @@
+use sqlx::QueryBuilder;
+
+use crate::{
+    dto::datetime::BrowserDateTimeDto, models::{ActionKind, TargetKind}, sanitizers::SearchTerm
+};
+
+#[derive(Debug)]
+pub struct LogsFilterDto<'r> {
+    pub actor: Option<&'r str>,
+    pub action: Option<ActionKind>,
+    pub target: Option<TargetKind>,
+    pub id: Option<&'r str>,
+    pub from: Option<BrowserDateTimeDto>,
+    pub until: Option<BrowserDateTimeDto>,
+    pub order: bool
+}
+
+impl LogsFilterDto<'_> {
+    fn any(&self) -> bool {
+        self.actor.is_some()
+            || self.action.is_some()
+            || self.target.is_some()
+            || self.id.is_some()
+            || self.from.is_some()
+            || self.until.is_some()
+    }
+
+    pub fn query<'a>(&self, query: &mut QueryBuilder<'a, sqlx::Postgres>) {
+        let mut added = false;
+        if self.any() {
+            query.push(" WHERE");
+        }
+
+
+        if let Some(action) = &self.action {
+            query.push(" action_kind = ");
+            query.push_bind(action.clone());
+            added = true;
+        }
+
+        if let Some(from) = &self.from {
+            if added {
+                query.push(" AND");
+            }
+
+            query.push(" stamp >= ");
+            query.push_bind(from.clone());
+            added = true;
+        }
+
+        if let Some(until) = &self.until {
+            if added {
+                query.push(" AND");
+            }
+
+            query.push(" stamp <= ");
+            query.push_bind(until.clone());
+            added = true;
+        }
+
+        if let Some(target) = &self.target {
+            if added {
+                query.push(" AND");
+            }
+            query.push(" target_kind = ");
+            query.push_bind(target.clone());
+            added = true;
+        }
+
+        if let Some(actor) = self.actor {
+            let term = SearchTerm::from(actor).anywhere();
+            if added {
+                query.push(" AND");
+            }
+            query.push(" actor LIKE ");
+            query.push_bind(term);
+            added = true;
+        }
+
+        if let Some(id) = self.id {
+            let term = SearchTerm::from(id).anywhere();
+            if added {
+                query.push(" AND");
+            }
+            query.push(" target_id LIKE ");
+            query.push_bind(term);
+        }
+    }
+}

--- a/src/dto/logs.rs
+++ b/src/dto/logs.rs
@@ -70,12 +70,11 @@ impl LogsFilterDto<'_> {
         }
 
         if let Some(actor) = self.actor {
-            let term = SearchTerm::from(actor).anywhere();
             if added {
                 query.push(" AND");
             }
-            query.push(" actor LIKE ");
-            query.push_bind(term);
+            query.push(" actor = ");
+            query.push_bind(actor.to_owned());
             added = true;
         }
 

--- a/src/integrations/gworkspace.rs
+++ b/src/integrations/gworkspace.rs
@@ -13,150 +13,152 @@ mod google;
 // can't use const because it wouldn't support async fn pointers for tasks
 pub static MANIFEST: LazyLock<super::Manifest> = LazyLock::new(|| {
     super::Manifest {
-    id: "gworkspace",
-    description: "Sync users and groups to Google Workspace",
-    settings: &[
-        super::Setting {
-            id: "mode",
-            secret: false,
-            name: "Mode",
-            description: "Level of structural mirroring to enforce",
-            r#type: super::SettingType::Select(&[
-                super::SelectSettingOption {
-                    value: "dry-run",
-                    display_name: "Dry run",
-                },
-                super::SelectSettingOption {
-                    value: "no-deletion",
-                    display_name: "Sync without removing existing entities",
-                },
-                super::SelectSettingOption {
-                    value: "full",
-                    display_name: "Complete push from Hive to Google directory",
-                },
-            ]),
-        },
-        super::Setting {
-            id: "primary-domain",
-            secret: false,
-            name: "Primary Domain",
-            description: "Where user accounts will be looked up & created",
-            r#type: super::SettingType::ShortText,
-        },
-        super::Setting {
-            id: "service-account-email",
-            secret: false,
-            name: "Service Account Email",
-            description: "Google Cloud service account with 'Service Account Token Creator' role",
-            r#type: super::SettingType::ShortText,
-        },
-        super::Setting {
-            id: "service-account-key",
-            secret: true,
-            name: "Service Account Private Key",
-            description: "Service account PEM-formatted private key (with header & footer)",
-            r#type: super::SettingType::LongText,
-        },
-        super::Setting {
-            id: "impersonate-user",
-            secret: false,
-            name: "Impersonate User",
-            description: "Email address of the domain admin to impersonate",
-            r#type: super::SettingType::ShortText,
-        },
-        super::Setting {
-            id: "group-whitelist",
-            secret: false,
-            name: "Group Whitelist",
-            description: "Comma-separated list of group email addresses to never delete",
-            r#type: super::SettingType::LongText,
-        },
-        super::Setting {
-            id: "alternative-domains",
-            secret: false,
-            name: "Alternative Domains",
-            description: "Comma-separated list of secondary domains where to lookup users",
-            r#type: super::SettingType::ShortText,
-        },
-    ],
-    tags: &[
-        super::Tag {
-            id: "sync",
-            description: "Entity that should be sync'd to Google Workspace",
-            has_content: false,
-            supports_groups: true,
-            supports_users: true,
-            self_service: false,
-        },
-        super::Tag {
-            id: "allow-external",
-            description: "Allow non-Workspace users to be added to the group",
-            has_content: false,
-            supports_groups: true,
-            supports_users: false,
-            self_service: false,
-        },
-        super::Tag {
-            id: "grace-period",
-            description: "Keep old members until a month past their membership end date",
-            has_content: false,
-            supports_groups: true,
-            supports_users: false,
-            self_service: false,
-        },
-        super::Tag {
-            id: "sensitive",
-            description: "Groups that must abide stricter requirements, such as having any grace period policy overridden",
-            has_content: false,
-            supports_groups: true,
-            supports_users: false,
-            self_service: false,
-        },
-        super::Tag {
-            id: "extra-member",
-            description: "Additional email address to be added to the group",
-            has_content: true,
-            supports_groups: true,
-            supports_users: false,
-            self_service: false,
-        },
-        super::Tag {
-            id: "extra-subgroup",
-            description: "Additional Google-only subgroup email address",
-            has_content: true,
-            supports_groups: true,
-            supports_users: false,
-            self_service: false,
-        },
-        super::Tag {
-            id: "embed-members",
-            // ^ this is generally unnecessary, but useful in cases where we
-            // cannot use "extra-subgroup": for example, if on Google group A
-            // should include the members of group B, but only those tracked by
-            // Hive and not any additional "extra-member"s of group B. in this
-            // case, we must express that group B's (Hive) members are embedded
-            // in group A's Google Group mirror
-            description: "Hive group from where to take additional Google-only members",
-            has_content: true,
-            supports_groups: true,
-            supports_users: false,
-            self_service: false,
-        },
-        super::Tag {
-            id: "personal-email",
-            description: "Personal email address to be used when no Workspace user is found",
-            has_content: true,
-            supports_groups: false,
-            supports_users: true,
-            self_service: true,
-        },
-    ],
-    tasks: &[super::Task {
-        id: "sync-to-directory",
-        schedule: "0 0 * * * *", // every hour
-        func: |mon, settings, db| Box::pin(sync_to_directory(mon, settings, db)),
-    }],
-}
+        id: "gworkspace",
+        description: "Sync users and groups to Google Workspace",
+        settings: &[
+            super::Setting {
+                id: "mode",
+                secret: false,
+                name: "Mode",
+                description: "Level of structural mirroring to enforce",
+                r#type: super::SettingType::Select(&[
+                    super::SelectSettingOption {
+                        value: "dry-run",
+                        display_name: "Dry run",
+                    },
+                    super::SelectSettingOption {
+                        value: "no-deletion",
+                        display_name: "Sync without removing existing entities",
+                    },
+                    super::SelectSettingOption {
+                        value: "full",
+                        display_name: "Complete push from Hive to Google directory",
+                    },
+                ]),
+            },
+            super::Setting {
+                id: "primary-domain",
+                secret: false,
+                name: "Primary Domain",
+                description: "Where user accounts will be looked up & created",
+                r#type: super::SettingType::ShortText,
+            },
+            super::Setting {
+                id: "service-account-email",
+                secret: false,
+                name: "Service Account Email",
+                description: "Google Cloud service account with 'Service Account Token Creator' \
+                              role",
+                r#type: super::SettingType::ShortText,
+            },
+            super::Setting {
+                id: "service-account-key",
+                secret: true,
+                name: "Service Account Private Key",
+                description: "Service account PEM-formatted private key (with header & footer)",
+                r#type: super::SettingType::LongText,
+            },
+            super::Setting {
+                id: "impersonate-user",
+                secret: false,
+                name: "Impersonate User",
+                description: "Email address of the domain admin to impersonate",
+                r#type: super::SettingType::ShortText,
+            },
+            super::Setting {
+                id: "group-whitelist",
+                secret: false,
+                name: "Group Whitelist",
+                description: "Comma-separated list of group email addresses to never delete",
+                r#type: super::SettingType::LongText,
+            },
+            super::Setting {
+                id: "alternative-domains",
+                secret: false,
+                name: "Alternative Domains",
+                description: "Comma-separated list of secondary domains where to lookup users",
+                r#type: super::SettingType::ShortText,
+            },
+        ],
+        tags: &[
+            super::Tag {
+                id: "sync",
+                description: "Entity that should be sync'd to Google Workspace",
+                has_content: false,
+                supports_groups: true,
+                supports_users: true,
+                self_service: false,
+            },
+            super::Tag {
+                id: "allow-external",
+                description: "Allow non-Workspace users to be added to the group",
+                has_content: false,
+                supports_groups: true,
+                supports_users: false,
+                self_service: false,
+            },
+            super::Tag {
+                id: "grace-period",
+                description: "Keep old members until a month past their membership end date",
+                has_content: false,
+                supports_groups: true,
+                supports_users: false,
+                self_service: false,
+            },
+            super::Tag {
+                id: "sensitive",
+                description: "Groups that must abide stricter requirements, such as having any \
+                              grace period policy overridden",
+                has_content: false,
+                supports_groups: true,
+                supports_users: false,
+                self_service: false,
+            },
+            super::Tag {
+                id: "extra-member",
+                description: "Additional email address to be added to the group",
+                has_content: true,
+                supports_groups: true,
+                supports_users: false,
+                self_service: false,
+            },
+            super::Tag {
+                id: "extra-subgroup",
+                description: "Additional Google-only subgroup email address",
+                has_content: true,
+                supports_groups: true,
+                supports_users: false,
+                self_service: false,
+            },
+            super::Tag {
+                id: "embed-members",
+                // ^ this is generally unnecessary, but useful in cases where we
+                // cannot use "extra-subgroup": for example, if on Google group A
+                // should include the members of group B, but only those tracked by
+                // Hive and not any additional "extra-member"s of group B. in this
+                // case, we must express that group B's (Hive) members are embedded
+                // in group A's Google Group mirror
+                description: "Hive group from where to take additional Google-only members",
+                has_content: true,
+                supports_groups: true,
+                supports_users: false,
+                self_service: false,
+            },
+            super::Tag {
+                id: "personal-email",
+                description: "Personal email address to be used when no Workspace user is found",
+                has_content: true,
+                supports_groups: false,
+                supports_users: true,
+                self_service: true,
+            },
+        ],
+        tasks: &[super::Task {
+            id: "sync-to-directory",
+            schedule: "0 0 * * * *", // every hour
+            func: |mon, settings, db| Box::pin(sync_to_directory(mon, settings, db)),
+        }],
+    }
 });
 
 #[derive(Deserialize, Clone, Copy)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -350,60 +350,64 @@ pub struct AuditLog {
 }
 
 impl AuditLog {
-    pub fn format_details(&self) -> Either<Vec<String>, JsonValue> {
-        match self.action_kind {
+    // Formats the details field see `object_to_list` and `object_to_change`.
+    // If it's not in the expected format default to `to_json_pretty`
+    pub fn format_details(&self) -> Either<Vec<String>, String> {
+        let formated = match self.action_kind {
             ActionKind::Create => self
                 .details
                 .as_object()
                 .and_then(|map| map.get("new"))
-                .and_then(|new| new.as_object())
-                .and_then(|map| {
-                    Some(
-                        map.iter()
-                            .map(|(key, value)| format!("{}: {}", key, value))
-                            .collect::<Vec<String>>(),
-                    )
-                })
-                .and_then(|list| Some(Either::Left(list)))
-                .unwrap_or(Either::Right(self.details.clone())),
+                .and_then(|new| object_to_list(new)),
             ActionKind::Delete => self
                 .details
                 .as_object()
                 .and_then(|map| map.get("old"))
-                .and_then(|new| new.as_object())
-                .and_then(|map| {
-                    Some(
-                        map.iter()
-                            .map(|(key, value)| format!("{}: {}", key, value))
-                            .collect::<Vec<String>>(),
-                    )
-                })
-                .and_then(|list| Some(Either::Left(list)))
-                .unwrap_or(Either::Right(self.details.clone())),
+                .and_then(|old| object_to_list(old)),
 
             ActionKind::Update => self
                 .details
                 .as_object()
                 .and_then(|map| map.get("new").zip(map.get("old")))
-                .and_then(|(new, old)| new.as_object().zip(old.as_object()))
-                .and_then(|(new, old)| {
-                    Some(
-                        new.iter()
-                            .filter_map(|(key, value)| {
-                                old.get(key)
-                                    .and_then(|old| Some((key, (old, value))))
-                                    .and_then(|(key, (old, new))| {
-                                        Some(format!("{}: {} => {}", key, old, new))
-                                    })
-                            })
-                            .collect::<Vec<String>>(),
-                    )
-                })
-                .and_then(|list| Some(Either::Left(list)))
-                .unwrap_or(Either::Right(self.details.clone())),
-            ActionKind::Impersonate => Either::Right(self.details.clone()),
+                .and_then(|(new, old)| object_to_change(new, old)),
+            ActionKind::Impersonate => None,
+        };
+
+        if let Some(formated) = formated {
+            Either::Left(formated)
+        } else {
+            Either::Right(
+                serde_json::to_string_pretty(&self.details)
+                    .unwrap_or(self.details.clone().to_string()),
+            )
         }
     }
+}
+
+// Convert json object to list of string with format `key: value`
+fn object_to_list(value: &serde_json::Value) -> Option<Vec<String>> {
+    value.as_object().and_then(|map| {
+        Some(
+            map.iter()
+                .map(|(key, value)| format!("{}: {}", key, value))
+                .collect::<Vec<String>>(),
+        )
+    })
+}
+
+// Convert json object to list of strings with format `key: old -> new`
+fn object_to_change(new: &serde_json::Value, old: &serde_json::Value) -> Option<Vec<String>> {
+    new.as_object().zip(old.as_object()).and_then(|(new, old)| {
+        Some(
+            new.iter()
+                .filter_map(|(key, value)| {
+                    old.get(key)
+                        .and_then(|old| Some((key, (old, value))))
+                        .and_then(|(key, (old, new))| Some(format!("{}: {} => {}", key, old, new)))
+                })
+                .collect::<Vec<String>>(),
+        )
+    })
 }
 
 #[derive(sqlx::Type, UriDisplayQuery, FromFormField, PartialEq, Clone, Debug)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,8 +2,7 @@ use std::{fmt, hash};
 
 use chrono::{DateTime, Local, NaiveDate};
 use rocket::{Either, FromFormField, UriDisplayQuery};
-use sqlx::types::JsonValue;
-use sqlx::FromRow;
+use sqlx::{types::JsonValue, FromRow};
 use uuid::Uuid;
 
 use crate::{

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
 use std::{fmt, hash};
 
 use chrono::{DateTime, Local, NaiveDate};
+use rocket::{Either, FromFormField, UriDisplayQuery};
+use sqlx::types::JsonValue;
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -337,7 +339,74 @@ impl AffiliatedTagAssignment {
     }
 }
 
-#[derive(sqlx::Type)]
+#[derive(FromRow)]
+pub struct AuditLog {
+    pub action_kind: ActionKind,
+    pub target_kind: TargetKind,
+    pub target_id: String,
+    pub actor: String,
+    pub details: serde_json::Value,
+    pub stamp: DateTime<Local>,
+}
+
+impl AuditLog {
+    pub fn format_details(&self) -> Either<Vec<String>, JsonValue> {
+        match self.action_kind {
+            ActionKind::Create => self
+                .details
+                .as_object()
+                .and_then(|map| map.get("new"))
+                .and_then(|new| new.as_object())
+                .and_then(|map| {
+                    Some(
+                        map.iter()
+                            .map(|(key, value)| format!("{}: {}", key, value))
+                            .collect::<Vec<String>>(),
+                    )
+                })
+                .and_then(|list| Some(Either::Left(list)))
+                .unwrap_or(Either::Right(self.details.clone())),
+            ActionKind::Delete => self
+                .details
+                .as_object()
+                .and_then(|map| map.get("old"))
+                .and_then(|new| new.as_object())
+                .and_then(|map| {
+                    Some(
+                        map.iter()
+                            .map(|(key, value)| format!("{}: {}", key, value))
+                            .collect::<Vec<String>>(),
+                    )
+                })
+                .and_then(|list| Some(Either::Left(list)))
+                .unwrap_or(Either::Right(self.details.clone())),
+
+            ActionKind::Update => self
+                .details
+                .as_object()
+                .and_then(|map| map.get("new").zip(map.get("old")))
+                .and_then(|(new, old)| new.as_object().zip(old.as_object()))
+                .and_then(|(new, old)| {
+                    Some(
+                        new.iter()
+                            .filter_map(|(key, value)| {
+                                old.get(key)
+                                    .and_then(|old| Some((key, (old, value))))
+                                    .and_then(|(key, (old, new))| {
+                                        Some(format!("{}: {} => {}", key, old, new))
+                                    })
+                            })
+                            .collect::<Vec<String>>(),
+                    )
+                })
+                .and_then(|list| Some(Either::Left(list)))
+                .unwrap_or(Either::Right(self.details.clone())),
+            ActionKind::Impersonate => Either::Right(self.details.clone()),
+        }
+    }
+}
+
+#[derive(sqlx::Type, UriDisplayQuery, FromFormField, PartialEq, Clone, Debug)]
 #[sqlx(type_name = "action_kind", rename_all = "snake_case")]
 pub enum ActionKind {
     Create,
@@ -346,7 +415,18 @@ pub enum ActionKind {
     Impersonate,
 }
 
-#[derive(sqlx::Type)]
+impl fmt::Display for ActionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ActionKind::Create => write!(f, "Create"),
+            ActionKind::Update => write!(f, "Update"),
+            ActionKind::Delete => write!(f, "Delete"),
+            ActionKind::Impersonate => write!(f, "Impersonate"),
+        }
+    }
+}
+
+#[derive(sqlx::Type, UriDisplayQuery, FromFormField, PartialEq, Clone, Debug)]
 #[sqlx(type_name = "target_kind", rename_all = "snake_case")]
 pub enum TargetKind {
     Group,
@@ -358,6 +438,22 @@ pub enum TargetKind {
     Permission,
     PermissionAssignment,
     User,
+}
+
+impl fmt::Display for TargetKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TargetKind::Group => write!(f, "Group"),
+            TargetKind::Membership => write!(f, "Membership"),
+            TargetKind::System => write!(f, "System"),
+            TargetKind::ApiToken => write!(f, "ApiToken"),
+            TargetKind::Tag => write!(f, "Tag"),
+            TargetKind::TagAssignment => write!(f, "TagAssignment"),
+            TargetKind::Permission => write!(f, "Permission"),
+            TargetKind::PermissionAssignment => write!(f, "PermissionAssignment"),
+            TargetKind::User => write!(f, "User"),
+        }
+    }
 }
 
 #[derive(FromRow)]

--- a/src/services/audit_logs.rs
+++ b/src/services/audit_logs.rs
@@ -33,8 +33,8 @@ where
 pub async fn get_logs_paged<'a, X>(
     db: X,
     filter: &LogsFilterDto<'_>,
-    offset: i32,
-    limit: i32,
+    offset: u32,
+    limit: u32,
 ) -> AppResult<Vec<AuditLog>>
 where
     X: sqlx::Executor<'a, Database = sqlx::Postgres>,
@@ -51,8 +51,12 @@ where
 
     filter.apply(&mut query);
 
-    query.push(" OFFSET ").push_bind(offset);
-    query.push(" LIMIT ").push_bind(limit);
+    query
+        .push(" OFFSET ")
+        .push_bind(i32::try_from(offset).unwrap_or(0));
+    query
+        .push(" LIMIT ")
+        .push_bind(i32::try_from(limit).unwrap_or(50));
 
     let logs = query.build_query_as().fetch_all(db).await?;
 

--- a/src/services/audit_logs.rs
+++ b/src/services/audit_logs.rs
@@ -49,13 +49,8 @@ where
         FROM audit_logs",
     );
 
-    filter.query(&mut query);
+    filter.apply(&mut query);
 
-    if filter.order {
-        query.push(" ORDER BY stamp ASC");
-    } else {
-        query.push(" ORDER BY stamp DESC");
-    }
     query.push(" OFFSET ").push_bind(offset);
     query.push(" LIMIT ").push_bind(limit);
 
@@ -64,7 +59,7 @@ where
     Ok(logs)
 }
 
-pub async fn get_actors<'a, X>(db: X) -> AppResult<Vec<String>>
+pub async fn list_actors<'a, X>(db: X) -> AppResult<Vec<String>>
 where
     X: sqlx::Executor<'a, Database = sqlx::Postgres>,
 {
@@ -79,7 +74,7 @@ where
     Ok(actors.into_iter().map(|actor| actor.0).collect())
 }
 
-pub async fn get_ids<'a, X>(db: X) -> AppResult<Vec<String>>
+pub async fn list_target_ids<'a, X>(db: X) -> AppResult<Vec<String>>
 where
     X: sqlx::Executor<'a, Database = sqlx::Postgres>,
 {

--- a/src/services/audit_logs.rs
+++ b/src/services/audit_logs.rs
@@ -1,6 +1,7 @@
 use crate::{
+    dto::logs::LogsFilterDto,
     errors::AppResult,
-    models::{ActionKind, TargetKind},
+    models::{ActionKind, AuditLog, TargetKind},
 };
 
 pub async fn add_entry<'a, 'q, X>(
@@ -27,4 +28,68 @@ where
     .await?;
 
     Ok(())
+}
+
+pub async fn get_logs_paged<'a, X>(
+    db: X,
+    filter: &LogsFilterDto<'_>,
+    offset: i32,
+    limit: i32,
+) -> AppResult<Vec<AuditLog>>
+where
+    X: sqlx::Executor<'a, Database = sqlx::Postgres>,
+{
+    let mut query = sqlx::QueryBuilder::new(
+        "SELECT action_kind,
+            target_kind,
+            target_id,
+            actor,
+            details,
+            stamp
+        FROM audit_logs",
+    );
+
+    filter.query(&mut query);
+
+    if filter.order {
+        query.push(" ORDER BY stamp ASC");
+    } else {
+        query.push(" ORDER BY stamp DESC");
+    }
+    query.push(" OFFSET ").push_bind(offset);
+    query.push(" LIMIT ").push_bind(limit);
+
+    let logs = query.build_query_as().fetch_all(db).await?;
+
+    Ok(logs)
+}
+
+pub async fn get_actors<'a, X>(db: X) -> AppResult<Vec<String>>
+where
+    X: sqlx::Executor<'a, Database = sqlx::Postgres>,
+{
+    let actors: Vec<(String,)> = sqlx::query_as(
+        "SELECT DISTINCT actor
+        FROM audit_logs
+        ORDER BY actor",
+    )
+    .fetch_all(db)
+    .await?;
+
+    Ok(actors.into_iter().map(|actor| actor.0).collect())
+}
+
+pub async fn get_ids<'a, X>(db: X) -> AppResult<Vec<String>>
+where
+    X: sqlx::Executor<'a, Database = sqlx::Postgres>,
+{
+    let ids: Vec<(String,)> = sqlx::query_as(
+        "SELECT DISTINCT target_id
+        FROM audit_logs
+        ORDER BY target_id",
+    )
+    .fetch_all(db)
+    .await?;
+
+    Ok(ids.into_iter().map(|id| id.0).collect())
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -21,6 +21,7 @@ mod permissions;
 mod systems;
 mod tags;
 mod user;
+mod logs;
 
 type RenderedTemplate = RawHtml<String>;
 
@@ -59,6 +60,7 @@ pub fn tree() -> RouteTree {
         user::routes(),
         systems::routes(),
         tags::routes(),
+        logs::routes(),
         rocket::routes![favicon, home, api_versions].into(),
     ])
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -17,11 +17,11 @@ mod api_tokens;
 mod auth;
 mod catchers;
 mod groups;
+mod logs;
 mod permissions;
 mod systems;
 mod tags;
 mod user;
-mod logs;
 
 type RenderedTemplate = RawHtml<String>;
 

--- a/src/web/logs.rs
+++ b/src/web/logs.rs
@@ -13,7 +13,7 @@ use rocket::Either;
 use rocket::{response::content::RawHtml, State};
 use sqlx::PgPool;
 
-const PAGE_SIZE: i32 = 50;
+const PAGE_SIZE: u32 = 50;
 
 pub fn routes() -> RouteTree {
     rocket::routes![get_audit_logs].into()
@@ -23,32 +23,20 @@ pub fn routes() -> RouteTree {
 #[template(path = "logs/details.html.j2")]
 struct ListLogsView<'r> {
     ctx: PageContext,
-    actor_filter: Option<&'r str>,
+    filter: LogsFilterDto<'r>,
     actors: Vec<String>,
-    action_filter: Option<ActionKind>,
-    target_filter: Option<TargetKind>,
-    id_filter: Option<&'r str>,
-    from_filter: Option<BrowserDateTimeDto>,
-    until_filter: Option<BrowserDateTimeDto>,
-    order: bool,
     ids: Vec<String>,
     logs: Vec<AuditLog>,
-    next_page: i32
+    next_page: u32,
 }
 
 #[derive(Template)]
 #[template(path = "logs/log-cells.html.j2")]
-struct LogsPartial<'r> {
+struct ListLogsPartial<'r> {
     ctx: PageContext,
     logs: Vec<AuditLog>,
-    next_page: i32,
-    actor_filter: Option<&'r str>,
-    action_filter: Option<ActionKind>,
-    target_filter: Option<TargetKind>,
-    id_filter: Option<&'r str>,
-    from_filter: Option<BrowserDateTimeDto>,
-    until_filter: Option<BrowserDateTimeDto>,
-    order: bool,
+    filter: LogsFilterDto<'r>,
+    next_page: u32,
 }
 
 #[rocket::get("/logs?<page>&<actor>&<id>&<action>&<target>&<from>&<until>&<order>")]
@@ -57,7 +45,7 @@ async fn get_audit_logs<'r>(
     ctx: PageContext,
     perms: &PermsEvaluator,
     partial: Option<HxRequest<'_>>,
-    page: Option<i32>,
+    page: Option<u32>,
     actor: Option<&'r str>,
     id: Option<&'r str>,
     action: Option<ActionKind>,
@@ -67,6 +55,8 @@ async fn get_audit_logs<'r>(
     order: bool,
 ) -> AppResult<RenderedTemplate> {
     perms.require(HivePermission::ViewLogs).await?;
+
+    let page = page.unwrap_or(1);
 
     let filter = LogsFilterDto {
         actor,
@@ -81,64 +71,31 @@ async fn get_audit_logs<'r>(
     let actors = audit_logs::list_actors(db.inner()).await?;
     let ids = audit_logs::list_target_ids(db.inner()).await?;
 
-    if let Some(page) = page {
-        if partial.is_some() {
-            let logs =
-                audit_logs::get_logs_paged(db.inner(), &filter, page * PAGE_SIZE, PAGE_SIZE)
-                    .await?;
+    let logs = audit_logs::get_logs_paged(
+        db.inner(),
+        &filter,
+        page.saturating_sub(1) * PAGE_SIZE,
+        PAGE_SIZE,
+    )
+    .await?;
 
-            let template = LogsPartial {
-                ctx,
-                logs,
-                next_page: page + 1,
-                actor_filter: actor,
-                id_filter: id,
-                action_filter: action,
-                target_filter: target,
-                from_filter: from,
-                until_filter: until,
-                order,
-            };
+    if partial.is_some() {
+        let template = ListLogsPartial {
+            ctx,
+            logs,
+            filter,
+            next_page: page + 1,
+        };
 
-            Ok(RawHtml(template.render()?))
-        } else {
-            let logs =
-                audit_logs::get_logs_paged(db.inner(), &filter, page * PAGE_SIZE, PAGE_SIZE)
-                    .await?;
-
-            let template = ListLogsView {
-                ctx,
-                logs,
-                next_page: page + 1,
-                actors,
-                ids,
-                actor_filter: actor,
-                id_filter: id,
-                action_filter: action,
-                target_filter: target,
-                from_filter: from,
-                until_filter: until,
-                order,
-            };
-
-            Ok(RawHtml(template.render()?))
-        }
+        Ok(RawHtml(template.render()?))
     } else {
-        let logs = audit_logs::get_logs_paged(db.inner(), &filter, 0, PAGE_SIZE).await?;
-
         let template = ListLogsView {
             ctx,
             logs,
-            next_page: 1,
+            filter,
+            next_page: page + 1,
             actors,
             ids,
-            actor_filter: actor,
-            id_filter: id,
-            action_filter: action,
-            target_filter: target,
-            from_filter: from,
-            until_filter: until,
-            order,
         };
 
         Ok(RawHtml(template.render()?))

--- a/src/web/logs.rs
+++ b/src/web/logs.rs
@@ -1,0 +1,146 @@
+use crate::{
+    dto::{datetime::BrowserDateTimeDto, logs::LogsFilterDto},
+    errors::AppResult,
+    guards::{context::PageContext, headers::HxRequest, perms::PermsEvaluator},
+    models::{ActionKind, AuditLog, TargetKind},
+    perms::HivePermission,
+    routing::RouteTree,
+    services::audit_logs,
+    web::RenderedTemplate,
+};
+use rinja::Template;
+use rocket::Either;
+use rocket::{response::content::RawHtml, State};
+use sqlx::PgPool;
+
+const PAGE_SIZE: i32 = 50;
+
+pub fn routes() -> RouteTree {
+    rocket::routes![get_audit_logs].into()
+}
+
+#[derive(Template)]
+#[template(path = "logs/details.html.j2")]
+struct LogsDetailsView<'r> {
+    ctx: PageContext,
+    actor_filter: Option<&'r str>,
+    actors: Vec<String>,
+    action_filter: Option<ActionKind>,
+    target_filter: Option<TargetKind>,
+    id_filter: Option<&'r str>,
+    from_filter: Option<BrowserDateTimeDto>,
+    until_filter: Option<BrowserDateTimeDto>,
+    order: bool,
+    ids: Vec<String>,
+    logs: Vec<AuditLog>,
+    next_page: i32
+}
+
+#[derive(Template)]
+#[template(path = "logs/log-cells.html.j2")]
+struct LogsPartial<'r> {
+    ctx: PageContext,
+    logs: Vec<AuditLog>,
+    next_page: i32,
+    actor_filter: Option<&'r str>,
+    action_filter: Option<ActionKind>,
+    target_filter: Option<TargetKind>,
+    id_filter: Option<&'r str>,
+    from_filter: Option<BrowserDateTimeDto>,
+    until_filter: Option<BrowserDateTimeDto>,
+    order: bool,
+}
+
+#[rocket::get("/logs?<page>&<actor>&<id>&<action>&<target>&<from>&<until>&<order>")]
+async fn get_audit_logs<'r>(
+    db: &State<PgPool>,
+    ctx: PageContext,
+    perms: &PermsEvaluator,
+    partial: Option<HxRequest<'_>>,
+    page: Option<i32>,
+    actor: Option<&'r str>,
+    id: Option<&'r str>,
+    action: Option<ActionKind>,
+    target: Option<TargetKind>,
+    from: Option<BrowserDateTimeDto>,
+    until: Option<BrowserDateTimeDto>,
+    order: bool,
+) -> AppResult<RenderedTemplate> {
+    perms.require(HivePermission::ViewLogs).await?;
+
+    let filters = LogsFilterDto {
+        actor,
+        action: action.clone(),
+        target: target.clone(),
+        id,
+        until: until.clone(),
+        from: from.clone(),
+        order,
+    };
+
+    let actors = audit_logs::get_actors(db.inner()).await?;
+    let ids = audit_logs::get_ids(db.inner()).await?;
+
+    if let Some(page) = page {
+        if partial.is_some() {
+            let logs =
+                audit_logs::get_logs_paged(db.inner(), &filters, page * PAGE_SIZE, PAGE_SIZE)
+                    .await?;
+
+            let template = LogsPartial {
+                ctx,
+                logs,
+                next_page: page + 1,
+                actor_filter: actor,
+                id_filter: id,
+                action_filter: action,
+                target_filter: target,
+                from_filter: from,
+                until_filter: until,
+                order,
+            };
+
+            Ok(RawHtml(template.render()?))
+        } else {
+            let logs =
+                audit_logs::get_logs_paged(db.inner(), &filters, page * PAGE_SIZE, PAGE_SIZE)
+                    .await?;
+
+            let template = LogsDetailsView {
+                ctx,
+                logs,
+                next_page: page + 1,
+                actors,
+                ids,
+                actor_filter: actor,
+                id_filter: id,
+                action_filter: action,
+                target_filter: target,
+                from_filter: from,
+                until_filter: until,
+                order,
+            };
+
+            Ok(RawHtml(template.render()?))
+        }
+    } else {
+        let logs = audit_logs::get_logs_paged(db.inner(), &filters, 0, PAGE_SIZE).await?;
+
+        let template = LogsDetailsView {
+            ctx,
+            logs,
+            next_page: 1,
+            actors,
+            ids,
+            actor_filter: actor,
+            id_filter: id,
+            action_filter: action,
+            target_filter: target,
+            from_filter: from,
+            until_filter: until,
+            order,
+        };
+
+        Ok(RawHtml(template.render()?))
+    }
+}

--- a/src/web/logs.rs
+++ b/src/web/logs.rs
@@ -39,34 +39,18 @@ struct ListLogsPartial<'r> {
     next_page: u32,
 }
 
-#[rocket::get("/logs?<page>&<actor>&<id>&<action>&<target>&<from>&<until>&<order>")]
+#[rocket::get("/logs?<page>&<filter..>")]
 async fn get_audit_logs<'r>(
     db: &State<PgPool>,
     ctx: PageContext,
     perms: &PermsEvaluator,
     partial: Option<HxRequest<'_>>,
+    filter: LogsFilterDto<'_>,
     page: Option<u32>,
-    actor: Option<&'r str>,
-    id: Option<&'r str>,
-    action: Option<ActionKind>,
-    target: Option<TargetKind>,
-    from: Option<BrowserDateTimeDto>,
-    until: Option<BrowserDateTimeDto>,
-    order: bool,
 ) -> AppResult<RenderedTemplate> {
     perms.require(HivePermission::ViewLogs).await?;
 
     let page = page.unwrap_or(1);
-
-    let filter = LogsFilterDto {
-        actor,
-        action: action.clone(),
-        target: target.clone(),
-        id,
-        until: until.clone(),
-        from: from.clone(),
-        order,
-    };
 
     let actors = audit_logs::list_actors(db.inner()).await?;
     let ids = audit_logs::list_target_ids(db.inner()).await?;

--- a/src/web/logs.rs
+++ b/src/web/logs.rs
@@ -21,7 +21,7 @@ pub fn routes() -> RouteTree {
 
 #[derive(Template)]
 #[template(path = "logs/details.html.j2")]
-struct LogsDetailsView<'r> {
+struct ListLogsView<'r> {
     ctx: PageContext,
     actor_filter: Option<&'r str>,
     actors: Vec<String>,
@@ -68,7 +68,7 @@ async fn get_audit_logs<'r>(
 ) -> AppResult<RenderedTemplate> {
     perms.require(HivePermission::ViewLogs).await?;
 
-    let filters = LogsFilterDto {
+    let filter = LogsFilterDto {
         actor,
         action: action.clone(),
         target: target.clone(),
@@ -78,13 +78,13 @@ async fn get_audit_logs<'r>(
         order,
     };
 
-    let actors = audit_logs::get_actors(db.inner()).await?;
-    let ids = audit_logs::get_ids(db.inner()).await?;
+    let actors = audit_logs::list_actors(db.inner()).await?;
+    let ids = audit_logs::list_target_ids(db.inner()).await?;
 
     if let Some(page) = page {
         if partial.is_some() {
             let logs =
-                audit_logs::get_logs_paged(db.inner(), &filters, page * PAGE_SIZE, PAGE_SIZE)
+                audit_logs::get_logs_paged(db.inner(), &filter, page * PAGE_SIZE, PAGE_SIZE)
                     .await?;
 
             let template = LogsPartial {
@@ -103,10 +103,10 @@ async fn get_audit_logs<'r>(
             Ok(RawHtml(template.render()?))
         } else {
             let logs =
-                audit_logs::get_logs_paged(db.inner(), &filters, page * PAGE_SIZE, PAGE_SIZE)
+                audit_logs::get_logs_paged(db.inner(), &filter, page * PAGE_SIZE, PAGE_SIZE)
                     .await?;
 
-            let template = LogsDetailsView {
+            let template = ListLogsView {
                 ctx,
                 logs,
                 next_page: page + 1,
@@ -124,9 +124,9 @@ async fn get_audit_logs<'r>(
             Ok(RawHtml(template.render()?))
         }
     } else {
-        let logs = audit_logs::get_logs_paged(db.inner(), &filters, 0, PAGE_SIZE).await?;
+        let logs = audit_logs::get_logs_paged(db.inner(), &filter, 0, PAGE_SIZE).await?;
 
-        let template = LogsDetailsView {
+        let template = ListLogsView {
             ctx,
             logs,
             next_page: 1,

--- a/src/web/logs.rs
+++ b/src/web/logs.rs
@@ -1,3 +1,7 @@
+use rinja::Template;
+use rocket::{response::content::RawHtml, Either, State};
+use sqlx::PgPool;
+
 use crate::{
     dto::{datetime::BrowserDateTimeDto, logs::LogsFilterDto},
     errors::AppResult,
@@ -8,10 +12,6 @@ use crate::{
     services::audit_logs,
     web::RenderedTemplate,
 };
-use rinja::Template;
-use rocket::Either;
-use rocket::{response::content::RawHtml, State};
-use sqlx::PgPool;
 
 const PAGE_SIZE: u32 = 50;
 

--- a/templates/logs/details.html.j2
+++ b/templates/logs/details.html.j2
@@ -11,23 +11,23 @@
 {% block content %}
 <form method="get" hx-boost="true" hx-target="#logs-list" hx-indicator="#logs-list"
     hx-trigger="submit, change, search, input changed delay:500ms">
-    <input type="hidden" name="page" value="0" />
+    <input type="hidden" name="page" value="1" />
     <div class="grid">
         <label>
             {{ ctx.t("logs.list.control.from.label") }}
-            <input type="datetime-local" name="from" value={% call utils::stringify_option(from_filter) %} />
+            <input type="datetime-local" name="from" value={% call utils::stringify_option(filter.from) %} />
         </label>
 
         <label>
             {{ ctx.t("logs.list.control.until.label") }}
-            <input type="datetime-local" name="until" value={% call utils::stringify_option(until_filter) %} />
+            <input type="datetime-local" name="until" value={% call utils::stringify_option(filter.until) %} />
         </label>
 
         <label>
             {{ ctx.t("logs.list.control.actor.label") }}
             <input list="actors" name="actor" 
                 placeholder="{{ ctx.t("logs.list.control.actor.option.any") }}"
-                value="{{ actor_filter.unwrap_or("") }}" />
+                value="{{ filter.actor.unwrap_or("") }}" />
         </label>
 
         <datalist id="actors">
@@ -41,19 +41,19 @@
         <label>
             {{ ctx.t("logs.list.control.action.label") }}
             <select name="action">
-                <option value="" {%- if action_filter.is_none() %} selected {%- endif -%}>
+                <option value="" {%- if filter.action.is_none() %} selected {%- endif -%}>
                     {{ ctx.t("logs.list.control.action.option.any") }}
                 </option>
-                <option {% call utils::optional_option(ActionKind::Create, action_filter) %}>
+                <option {% call utils::optional_option(ActionKind::Create, filter.action) %}>
                     {{ ctx.t("logs.list.control.action.option.create") }}
                 </option>
-                <option {% call utils::optional_option(ActionKind::Update, action_filter) %}>
+                <option {% call utils::optional_option(ActionKind::Update, filter.action) %}>
                     {{ ctx.t("logs.list.control.action.option.update") }}
                 </option>
-                <option {% call utils::optional_option(ActionKind::Delete, action_filter) %}>
+                <option {% call utils::optional_option(ActionKind::Delete, filter.action) %}>
                     {{ ctx.t("logs.list.control.action.option.delete") }}
                 </option>
-                <option {% call utils::optional_option(ActionKind::Impersonate, action_filter) %}>
+                <option {% call utils::optional_option(ActionKind::Impersonate, filter.action) %}>
                     {{ ctx.t("logs.list.control.action.option.impersonate") }}
                 </option>
             </select>
@@ -62,34 +62,34 @@
         <label>
             {{ ctx.t("logs.list.control.target.label") }}
             <select name="target">
-                <option value="" {%- if action_filter.is_none() %} selected {%- endif -%}>
+                <option value="" {%- if filter.target.is_none() %} selected {%- endif -%}>
                     {{ ctx.t("logs.list.control.target.option.any") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::Group, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::Group, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.group") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::Membership, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::Membership, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.membership") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::System, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::System, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.system") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::ApiToken, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::ApiToken, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.api-token") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::Tag, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::Tag, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.tag") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::TagAssignment, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::TagAssignment, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.tag-assignment") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::Permission, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::Permission, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.permission") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::PermissionAssignment, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::PermissionAssignment, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.permission-assignment") }}
                 </option>
-                <option {% call utils::optional_option(TargetKind::User, target_filter) %}>
+                <option {% call utils::optional_option(TargetKind::User, filter.target) %}>
                     {{ ctx.t("logs.list.control.target.option.user") }}
                 </option>
             </select>
@@ -99,7 +99,7 @@
             {{ ctx.t("logs.list.control.id.label") }}
             <input list="ids" name="id"
                 placeholder="{{ ctx.t("logs.list.control.id.option.any") }}"
-                value="{{ id_filter.unwrap_or("") }}" />
+                value="{{ filter.id.unwrap_or("") }}" />
         </label>
 
         <datalist id="ids">
@@ -110,7 +110,7 @@
     </div>
 
     <label>
-        <input type="checkbox" role="switch" name="order" />
+        <input type="checkbox" role="switch" name="order"/>
         {{ ctx.t("logs.list.control.order.label") }}
     </label>
 </form>

--- a/templates/logs/details.html.j2
+++ b/templates/logs/details.html.j2
@@ -1,0 +1,139 @@
+{% extends "base.html.j2" %}
+
+{%- import "utils.html.j2" as utils -%}
+
+{% block title %} Logs {% endblock title %}
+
+{% block heading %}
+    <h1>Logs</h1>
+{% endblock heading %}
+
+{% block content %}
+<form method="get" hx-boost="true" hx-target="#logs-list" hx-indicator="#logs-list"
+    hx-trigger="submit, change, search, input changed delay:500ms">
+    <input type="hidden" name="page" value="0" />
+    <div class="grid">
+        <label>
+            {{ ctx.t("logs.details.control.from.label") }}
+            <input type="datetime-local" name="from" value={% call utils::stringify_option(from_filter) %} />
+        </label>
+
+        <label>
+            {{ ctx.t("logs.details.control.until.label") }}
+            <input type="datetime-local" name="until" value={% call utils::stringify_option(until_filter) %} />
+        </label>
+
+        <label>
+            {{ ctx.t("logs.details.control.actor.label") }}
+            <input list="actors" name="actor" 
+                placeholder="{{ ctx.t("logs.details.control.actor.option.any") }}"
+                value="{{ actor_filter.unwrap_or("") }}" />
+        </label>
+
+        <datalist id="actors">
+            {% for actor in actors %}
+            <option value={{actor}}>
+            {% endfor %}
+        </datalist>
+    </div>
+
+    <div class="grid">
+        <label>
+            {{ ctx.t("logs.details.control.action.label") }}
+            <select name="action">
+                <option value="" {%- if action_filter.is_none() %} selected {%- endif -%}>
+                    {{ ctx.t("logs.details.control.action.option.any") }}
+                </option>
+                <option {% call utils::optional_option(ActionKind::Create, action_filter) %}>
+                    {{ ctx.t("logs.details.control.action.option.create") }}
+                </option>
+                <option {% call utils::optional_option(ActionKind::Update, action_filter) %}>
+                    {{ ctx.t("logs.details.control.action.option.update") }}
+                </option>
+                <option {% call utils::optional_option(ActionKind::Delete, action_filter) %}>
+                    {{ ctx.t("logs.details.control.action.option.delete") }}
+                </option>
+                <option {% call utils::optional_option(ActionKind::Impersonate, action_filter) %}>
+                    {{ ctx.t("logs.details.control.action.option.impersonate") }}
+                </option>
+            </select>
+        </label>
+
+        <label>
+            {{ ctx.t("logs.details.control.target.label") }}
+            <select name="target">
+                <option value="" {%- if action_filter.is_none() %} selected {%- endif -%}>
+                    {{ ctx.t("logs.details.control.target.option.any") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::Group, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.group") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::Membership, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.membership") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::System, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.system") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::ApiToken, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.apitoken") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::Tag, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.tag") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::TagAssignment, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.tagassignment") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::Permission, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.permission") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::PermissionAssignment, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.permissionassignment") }}
+                </option>
+                <option {% call utils::optional_option(TargetKind::User, target_filter) %}>
+                    {{ ctx.t("logs.details.control.target.option.user") }}
+                </option>
+            </select>
+        </label>
+
+        <label>
+            {{ ctx.t("logs.details.control.id.label") }}
+            <input list="ids" name="id"
+                placeholder="{{ ctx.t("logs.details.control.id.option.any") }}"
+                value="{{ id_filter.unwrap_or("") }}" />
+        </label>
+
+        <datalist id="ids">
+            {% for id in ids %}
+            <option value={{id}}>
+            {% endfor %}
+        </datalist>
+    </div>
+
+    <label>
+        <input type="checkbox" role="switch" name="order" />
+        {{ ctx.t("logs.details.control.order.label") }}
+    </label>
+</form>
+
+<main class="overflow-auto">
+    <table class="striped">
+        <thead>
+            <th scope="col">Time</th>
+            <th scope="col">Actor</th>
+            <th scope="col" class="center">Action</th>
+            <th scope="col" class="center">Target</th>
+            <th scope="col">ID</th>
+            <th scope="col">Details</th>
+        </thead>
+        <tbody id="logs-list">
+            <tr class="if-table-empty">
+                <td colspan="5">
+                    <span class="material-icons">block</span>
+                    {{ ctx.t("logs.list.empty") }}
+                </td>
+            </tr>
+            {% include "log-cells.html.j2" %}
+        </tbody>
+    </table>
+</main>
+{% endblock content %}

--- a/templates/logs/details.html.j2
+++ b/templates/logs/details.html.j2
@@ -14,19 +14,19 @@
     <input type="hidden" name="page" value="0" />
     <div class="grid">
         <label>
-            {{ ctx.t("logs.details.control.from.label") }}
+            {{ ctx.t("logs.list.control.from.label") }}
             <input type="datetime-local" name="from" value={% call utils::stringify_option(from_filter) %} />
         </label>
 
         <label>
-            {{ ctx.t("logs.details.control.until.label") }}
+            {{ ctx.t("logs.list.control.until.label") }}
             <input type="datetime-local" name="until" value={% call utils::stringify_option(until_filter) %} />
         </label>
 
         <label>
-            {{ ctx.t("logs.details.control.actor.label") }}
+            {{ ctx.t("logs.list.control.actor.label") }}
             <input list="actors" name="actor" 
-                placeholder="{{ ctx.t("logs.details.control.actor.option.any") }}"
+                placeholder="{{ ctx.t("logs.list.control.actor.option.any") }}"
                 value="{{ actor_filter.unwrap_or("") }}" />
         </label>
 
@@ -39,66 +39,66 @@
 
     <div class="grid">
         <label>
-            {{ ctx.t("logs.details.control.action.label") }}
+            {{ ctx.t("logs.list.control.action.label") }}
             <select name="action">
                 <option value="" {%- if action_filter.is_none() %} selected {%- endif -%}>
-                    {{ ctx.t("logs.details.control.action.option.any") }}
+                    {{ ctx.t("logs.list.control.action.option.any") }}
                 </option>
                 <option {% call utils::optional_option(ActionKind::Create, action_filter) %}>
-                    {{ ctx.t("logs.details.control.action.option.create") }}
+                    {{ ctx.t("logs.list.control.action.option.create") }}
                 </option>
                 <option {% call utils::optional_option(ActionKind::Update, action_filter) %}>
-                    {{ ctx.t("logs.details.control.action.option.update") }}
+                    {{ ctx.t("logs.list.control.action.option.update") }}
                 </option>
                 <option {% call utils::optional_option(ActionKind::Delete, action_filter) %}>
-                    {{ ctx.t("logs.details.control.action.option.delete") }}
+                    {{ ctx.t("logs.list.control.action.option.delete") }}
                 </option>
                 <option {% call utils::optional_option(ActionKind::Impersonate, action_filter) %}>
-                    {{ ctx.t("logs.details.control.action.option.impersonate") }}
+                    {{ ctx.t("logs.list.control.action.option.impersonate") }}
                 </option>
             </select>
         </label>
 
         <label>
-            {{ ctx.t("logs.details.control.target.label") }}
+            {{ ctx.t("logs.list.control.target.label") }}
             <select name="target">
                 <option value="" {%- if action_filter.is_none() %} selected {%- endif -%}>
-                    {{ ctx.t("logs.details.control.target.option.any") }}
+                    {{ ctx.t("logs.list.control.target.option.any") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::Group, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.group") }}
+                    {{ ctx.t("logs.list.control.target.option.group") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::Membership, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.membership") }}
+                    {{ ctx.t("logs.list.control.target.option.membership") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::System, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.system") }}
+                    {{ ctx.t("logs.list.control.target.option.system") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::ApiToken, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.apitoken") }}
+                    {{ ctx.t("logs.list.control.target.option.api-token") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::Tag, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.tag") }}
+                    {{ ctx.t("logs.list.control.target.option.tag") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::TagAssignment, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.tagassignment") }}
+                    {{ ctx.t("logs.list.control.target.option.tag-assignment") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::Permission, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.permission") }}
+                    {{ ctx.t("logs.list.control.target.option.permission") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::PermissionAssignment, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.permissionassignment") }}
+                    {{ ctx.t("logs.list.control.target.option.permission-assignment") }}
                 </option>
                 <option {% call utils::optional_option(TargetKind::User, target_filter) %}>
-                    {{ ctx.t("logs.details.control.target.option.user") }}
+                    {{ ctx.t("logs.list.control.target.option.user") }}
                 </option>
             </select>
         </label>
 
         <label>
-            {{ ctx.t("logs.details.control.id.label") }}
+            {{ ctx.t("logs.list.control.id.label") }}
             <input list="ids" name="id"
-                placeholder="{{ ctx.t("logs.details.control.id.option.any") }}"
+                placeholder="{{ ctx.t("logs.list.control.id.option.any") }}"
                 value="{{ id_filter.unwrap_or("") }}" />
         </label>
 
@@ -111,7 +111,7 @@
 
     <label>
         <input type="checkbox" role="switch" name="order" />
-        {{ ctx.t("logs.details.control.order.label") }}
+        {{ ctx.t("logs.list.control.order.label") }}
     </label>
 </form>
 

--- a/templates/logs/log-cells.html.j2
+++ b/templates/logs/log-cells.html.j2
@@ -14,58 +14,58 @@
 
         {% match log.action_kind %}
             {% when ActionKind::Create %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.create") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.action.option.create") }}">
             <span class="material-icons">add</span>
         </td>
             {% when ActionKind::Delete %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.delete") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.action.option.delete") }}">
             <span class="material-icons">delete</span>
         </td>
             {% when ActionKind::Update %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.update") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.action.option.update") }}">
             <span class="material-icons">update</span>
         </td>
             {% when ActionKind::Impersonate %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.impersonate") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.action.option.impersonate") }}">
             <span class="material-icons">person</span>
         </td>
         {% endmatch %}
 
         {% match log.target_kind %}
             {% when TargetKind::Group %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.group") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.group") }}">
             <span class="material-icons">group</span>
         </td>
             {% when TargetKind::Membership %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.membership") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.membership") }}">
             <span class="material-icons">person</span>
         </td>
             {% when TargetKind::System %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.system") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.system") }}">
             <span class="material-icons">build</span>
         </td>
             {% when TargetKind::ApiToken %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.apitoken") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.api-token") }}">
             <span class="material-icons">badge</span>
         </td>
             {% when TargetKind::Tag %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.tag") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.tag") }}">
             <span class="material-icons">label</span>
         </td>
             {% when TargetKind::TagAssignment %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.tagassignment") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.tag-assignment") }}">
             <span class="material-icons">new_label</span>
         </td>
             {% when TargetKind::Permission %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.permission") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.permission") }}">
             <span class="material-icons">shield</span>
         </td>
             {% when TargetKind::PermissionAssignment %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.permissionassignment") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.permission-assignment") }}">
             <span class="material-icons">add_moderator</span>
         </td>
             {% when TargetKind::User %}
-        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.user") }}">
+        <td class="center" data-tooltip="{{ ctx.t("logs.list.control.target.option.user") }}">
             <span class="material-icons">person_outline</span>
         </td>
         {% endmatch %}

--- a/templates/logs/log-cells.html.j2
+++ b/templates/logs/log-cells.html.j2
@@ -8,7 +8,7 @@
     {% else %}
     <tr>
     {% endif %}
-        {% let time = BrowserDateTimeDto(log.stamp.clone()) %}
+        {% let time = log.stamp.format("%Y-%m-%d %H:%M:%S") %}
         <td>{{ time }}</td>
         <td>{{ log.actor }}</td>
 

--- a/templates/logs/log-cells.html.j2
+++ b/templates/logs/log-cells.html.j2
@@ -1,0 +1,88 @@
+{%- import "utils.html.j2" as utils -%}
+
+{% for log in logs %}
+    {% if loop.last %}
+    <tr hx-get="/logs?page={{ next_page }}&actor={{ actor_filter.unwrap_or("") }}&action={%- call utils::stringify_option(action_filter) -%}&target={%- call utils::stringify_option(target_filter) -%}&id={%- call utils::stringify_option(id_filter) -%}&from={%- call utils::stringify_option(from_filter) -%}&until={%- call utils::stringify_option(until_filter) -%}&order={{ order }}"
+        hx-trigger="revealed"
+        hx-swap="afterend">
+    {% else %}
+    <tr>
+    {% endif %}
+        {% let time = BrowserDateTimeDto(log.stamp.clone()) %}
+        <td>{{ time }}</td>
+        <td>{{ log.actor }}</td>
+
+        {% match log.action_kind %}
+            {% when ActionKind::Create %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.create") }}">
+            <span class="material-icons">add</span>
+        </td>
+            {% when ActionKind::Delete %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.delete") }}">
+            <span class="material-icons">delete</span>
+        </td>
+            {% when ActionKind::Update %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.update") }}">
+            <span class="material-icons">update</span>
+        </td>
+            {% when ActionKind::Impersonate %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.action.option.impersonate") }}">
+            <span class="material-icons">person</span>
+        </td>
+        {% endmatch %}
+
+        {% match log.target_kind %}
+            {% when TargetKind::Group %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.group") }}">
+            <span class="material-icons">group</span>
+        </td>
+            {% when TargetKind::Membership %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.membership") }}">
+            <span class="material-icons">person</span>
+        </td>
+            {% when TargetKind::System %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.system") }}">
+            <span class="material-icons">build</span>
+        </td>
+            {% when TargetKind::ApiToken %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.apitoken") }}">
+            <span class="material-icons">badge</span>
+        </td>
+            {% when TargetKind::Tag %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.tag") }}">
+            <span class="material-icons">label</span>
+        </td>
+            {% when TargetKind::TagAssignment %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.tagassignment") }}">
+            <span class="material-icons">new_label</span>
+        </td>
+            {% when TargetKind::Permission %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.permission") }}">
+            <span class="material-icons">shield</span>
+        </td>
+            {% when TargetKind::PermissionAssignment %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.permissionassignment") }}">
+            <span class="material-icons">add_moderator</span>
+        </td>
+            {% when TargetKind::User %}
+        <td class="center" data-tooltip="{{ ctx.t("logs.details.control.target.option.user") }}">
+            <span class="material-icons">person_outline</span>
+        </td>
+        {% endmatch %}
+        <td>{{ log.target_id }}</td>
+        {% let details = log.format_details() %}
+        <td>
+            <details>
+                <summary>Details</summary>
+        {% match details %}
+            {% when Either::Left(list) %}
+                {% for line in list%}
+            {{ line }}
+            <br>
+                {% endfor %}
+            {% when Either::Right(obj) %} {{ obj }}
+        {% endmatch %}
+            </details>
+        </td>
+    </tr>
+{% endfor %}

--- a/templates/logs/log-cells.html.j2
+++ b/templates/logs/log-cells.html.j2
@@ -2,7 +2,7 @@
 
 {% for log in logs %}
     {% if loop.last %}
-    <tr hx-get="/logs?page={{ next_page }}&actor={{ actor_filter.unwrap_or("") }}&action={%- call utils::stringify_option(action_filter) -%}&target={%- call utils::stringify_option(target_filter) -%}&id={%- call utils::stringify_option(id_filter) -%}&from={%- call utils::stringify_option(from_filter) -%}&until={%- call utils::stringify_option(until_filter) -%}&order={{ order }}"
+    <tr hx-get="/logs?page={{ next_page }}&actor={{ filter.actor.unwrap_or("") }}&action={%- call utils::stringify_option(filter.action) -%}&target={%- call utils::stringify_option(filter.target) -%}&id={%- call utils::stringify_option(filter.id) -%}&from={%- call utils::stringify_option(filter.from) -%}&until={%- call utils::stringify_option(filter.until) -%}&order={{ filter.order }}"
         hx-trigger="revealed"
         hx-swap="afterend">
     {% else %}

--- a/templates/utils.html.j2
+++ b/templates/utils.html.j2
@@ -41,6 +41,15 @@ selected
 {%- endif -%}
 {%- endmacro option %}
 
+{% macro optional_option(value, selected_value) -%}
+value="{{ value }}"
+{% if let Some(selected_value) = selected_value %}
+{%- if value == *selected_value -%}
+selected
+{%- endif -%}
+{%- endif -%}
+{%- endmacro optional_option %}
+
 
 {% macro stamp_or_never(option) -%}
 {%- if let Some(val) = option -%}
@@ -58,3 +67,10 @@ selected
 <span class="material-icons">close</span>
 {%- endif -%}
 {%- endmacro yn_indicator %}
+
+
+{% macro stringify_option(optional_term) -%}
+{%- if let Some(some_term) = optional_term -%}
+    {{ format!("{}", some_term) }}
+{%- endif -%}
+{%- endmacro stringify_option %}


### PR DESCRIPTION
Adds a log page that shows the systems audit logs. It uses infinite scroll because it felt like a more convenient way to view logs because they are something that is usually be scrolled through.

Resolves #16 